### PR TITLE
Adds requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv==1.0.1
 requests==2.32.3
 click==8.1.7
 openai==1.55.0
+groq==0.2.0


### PR DESCRIPTION
The devcontainer config file in `devcontainer.json` has a command to install neccessary libraries from a `requirements.txt` but none exist in the repository
To close #4 issue