### PR TITLE
add installation of ffmpeg via postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,5 +15,5 @@
         ]
       }
     },
-    "postCreateCommand": "pip install -r requirements.txt"
+    "postCreateCommand": "pip install -r requirements.txt && sudo apt update && sudo apt upgrade -y && sudo apt install ffmpeg -y"
   }


### PR DESCRIPTION
@nkkko Without this, once the user is inside the workspace spin off from `daytona create` he/she would have to install `ffmpeg` manually. This PR remove the need to do so

There would be follow up PR(s) to make the workspace have access to host machine directory in order to access videos/audios for transcribing

You know by default, containers are isolated from host machines and the videos/audios would be in the host machine.