### PR TITLE
Add AssemblyAI transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This tool automates the process of transcribing video files using multiple trans
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and AssemblyAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - AssemblyAI API
 
 ## Installation
 
@@ -53,6 +54,12 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # AssemblyAI
+   ASSEMBLYAI_API_KEY=your_assemblyai_api_key_here
+   ASSEMBLYAI_API_ENDPOINT=https://api.assemblyai.com/v2
+   ASSEMBLYAI_POLL_INTERVAL_SECONDS=3
+   ASSEMBLYAI_TIMEOUT_SECONDS=600
    ```
 
 ## Building and Installing the Package
@@ -115,11 +122,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api assemblyai` for AssemblyAI API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+AssemblyAI example:
+
+```
+sapat product_demo.mp4 --quality M --language en --api assemblyai
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +143,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and AssemblyAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.assemblyai import AssemblyAITranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'assemblyai'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure', or 'assemblyai')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "assemblyai":
+        transcriber = AssemblyAITranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/assemblyai.py
+++ b/src/sapat/transcription/assemblyai.py
@@ -1,0 +1,175 @@
+import os
+import time
+from typing import Optional
+
+import requests
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from .base import TranscriptionBase
+
+load_dotenv(".env")
+
+DEFAULT_ASSEMBLYAI_ENDPOINT = "https://api.assemblyai.com/v2"
+SUPPORTED_AUDIO_EXTENSIONS = (".mp3", ".wav", ".flac")
+
+
+class AssemblyAITranscription(TranscriptionBase):
+    """
+    AssemblyAI REST API implementation for transcription.
+    """
+
+    def __init__(
+        self,
+        temperature: float,
+        response_format: str = "json",
+        poll_interval_seconds: Optional[float] = None,
+        timeout_seconds: Optional[float] = None,
+    ):
+        self.api_key = os.getenv("ASSEMBLYAI_API_KEY")
+        self.endpoint = os.getenv(
+            "ASSEMBLYAI_API_ENDPOINT",
+            DEFAULT_ASSEMBLYAI_ENDPOINT,
+        ).rstrip("/")
+        self.model_name_chat = os.getenv("OPENAI_MODEL_NAME_CHAT")
+        self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        self.temperature = temperature
+        self.response_format = response_format
+        self.poll_interval_seconds = (
+            poll_interval_seconds
+            if poll_interval_seconds is not None
+            else float(os.getenv("ASSEMBLYAI_POLL_INTERVAL_SECONDS", "3"))
+        )
+        self.timeout_seconds = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else float(os.getenv("ASSEMBLYAI_TIMEOUT_SECONDS", "600"))
+        )
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Uploads an audio file to AssemblyAI, submits a transcript job, and polls
+        until the transcript is ready.
+        """
+        self._validate_audio_file(audio_file)
+        upload_url = self._upload_audio(audio_file)
+        transcript_id = self._submit_transcript(upload_url, **kwargs)
+        transcript = self._poll_transcript(transcript_id)
+
+        if self.response_format == "text":
+            return transcript.get("text", "")
+        return {
+            "text": transcript.get("text", ""),
+            "id": transcript_id,
+            "status": transcript.get("status"),
+        }
+
+    def generate_corrected_transcript(
+        self,
+        audio_file: str,
+        temperature: float,
+        system_prompt: str,
+    ):
+        """
+        Uses OpenAI chat completion settings, when configured, to clean up the
+        AssemblyAI transcript.
+        """
+        if not self.openai_api_key or not self.model_name_chat:
+            raise ValueError(
+                "Correction for AssemblyAI requires OPENAI_API_KEY and "
+                "OPENAI_MODEL_NAME_CHAT."
+            )
+
+        transcription = self.transcribe_audio(audio_file)
+        transcription_text = (
+            transcription.get("text", "")
+            if isinstance(transcription, dict)
+            else transcription
+        )
+
+        client = OpenAI(api_key=self.openai_api_key)
+        response = client.chat.completions.create(
+            model=self.model_name_chat,
+            temperature=temperature,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": transcription_text},
+            ],
+        )
+        return response.choices[0].message.content
+
+    def _upload_audio(self, audio_file: str):
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                f"{self.endpoint}/upload",
+                headers=self._headers(),
+                data=f,
+            )
+        self._raise_for_response(response, "AssemblyAI upload failed")
+        return response.json()["upload_url"]
+
+    def _submit_transcript(self, audio_url: str, **kwargs):
+        payload = {
+            "audio_url": audio_url,
+        }
+        language = kwargs.get("language")
+        if language:
+            payload["language_code"] = language
+
+        response = requests.post(
+            f"{self.endpoint}/transcript",
+            headers={**self._headers(), "Content-Type": "application/json"},
+            json=payload,
+        )
+        self._raise_for_response(response, "AssemblyAI transcript submission failed")
+        return response.json()["id"]
+
+    def _poll_transcript(self, transcript_id: str):
+        deadline = time.time() + self.timeout_seconds
+        while time.time() < deadline:
+            response = requests.get(
+                f"{self.endpoint}/transcript/{transcript_id}",
+                headers=self._headers(),
+            )
+            self._raise_for_response(response, "AssemblyAI transcript polling failed")
+            transcript = response.json()
+            status = transcript.get("status")
+            if status == "completed":
+                return transcript
+            if status == "error":
+                raise RuntimeError(
+                    f"AssemblyAI transcription failed: {transcript.get('error')}"
+                )
+            time.sleep(self.poll_interval_seconds)
+
+        raise TimeoutError(
+            f"AssemblyAI transcription timed out after {self.timeout_seconds} seconds."
+        )
+
+    def _headers(self):
+        if not self.api_key:
+            raise ValueError(
+                "ASSEMBLYAI_API_KEY is required for AssemblyAI transcription."
+            )
+        return {"Authorization": self.api_key}
+
+    def _raise_for_response(self, response, message: str):
+        if response.status_code >= 400:
+            raise RuntimeError(f"{message} ({response.status_code}): {response.text}")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise ValueError(
+                f"File size exceeds the maximum limit of {self.max_file_size_mb} MB."
+            )
+
+        if not str(audio_file).lower().endswith(SUPPORTED_AUDIO_EXTENSIONS):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {list(SUPPORTED_AUDIO_EXTENSIONS)}."
+            )

--- a/tests/test_assemblyai.py
+++ b/tests/test_assemblyai.py
@@ -1,0 +1,197 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import ANY, Mock, patch
+
+from sapat.transcription.assemblyai import AssemblyAITranscription
+
+
+class AssemblyAITranscriptionTest(unittest.TestCase):
+    def setUp(self):
+        self.env = patch.dict(
+            os.environ,
+            {
+                "ASSEMBLYAI_API_KEY": "test-key",
+                "ASSEMBLYAI_POLL_INTERVAL_SECONDS": "0",
+                "ASSEMBLYAI_TIMEOUT_SECONDS": "5",
+            },
+            clear=False,
+        )
+        self.env.start()
+        self.audio = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        self.audio.write(b"fake audio")
+        self.audio.close()
+
+    def tearDown(self):
+        self.env.stop()
+        os.unlink(self.audio.name)
+
+    @patch("sapat.transcription.assemblyai.requests.get")
+    @patch("sapat.transcription.assemblyai.requests.post")
+    def test_transcribes_uploaded_audio(self, post, get):
+        upload_response = Mock(status_code=200)
+        upload_response.json.return_value = {
+            "upload_url": "https://cdn.example/audio.mp3"
+        }
+        submit_response = Mock(status_code=200)
+        submit_response.json.return_value = {"id": "transcript-123"}
+        post.side_effect = [upload_response, submit_response]
+
+        poll_response = Mock(status_code=200)
+        poll_response.json.return_value = {
+            "status": "completed",
+            "text": "Hello from Daytona",
+        }
+        get.return_value = poll_response
+
+        transcriber = AssemblyAITranscription(temperature=0.3)
+        result = transcriber.transcribe_audio(self.audio.name, language="en")
+
+        self.assertEqual(result["text"], "Hello from Daytona")
+        self.assertEqual(result["id"], "transcript-123")
+        post.assert_any_call(
+            "https://api.assemblyai.com/v2/transcript",
+            headers={"Authorization": "test-key", "Content-Type": "application/json"},
+            json={"audio_url": "https://cdn.example/audio.mp3", "language_code": "en"},
+        )
+
+    @patch("sapat.transcription.assemblyai.requests.get")
+    @patch("sapat.transcription.assemblyai.requests.post")
+    def test_returns_plain_text_when_requested(self, post, get):
+        upload_response = Mock(status_code=200)
+        upload_response.json.return_value = {
+            "upload_url": "https://cdn.example/audio.mp3"
+        }
+        submit_response = Mock(status_code=200)
+        submit_response.json.return_value = {"id": "transcript-123"}
+        post.side_effect = [upload_response, submit_response]
+
+        poll_response = Mock(status_code=200)
+        poll_response.json.return_value = {
+            "status": "completed",
+            "text": "plain transcript",
+        }
+        get.return_value = poll_response
+
+        transcriber = AssemblyAITranscription(temperature=0.3, response_format="text")
+
+        self.assertEqual(
+            transcriber.transcribe_audio(self.audio.name),
+            "plain transcript",
+        )
+
+    @patch("sapat.transcription.assemblyai.requests.get")
+    @patch("sapat.transcription.assemblyai.requests.post")
+    def test_raises_when_transcript_job_errors(self, post, get):
+        upload_response = Mock(status_code=200)
+        upload_response.json.return_value = {
+            "upload_url": "https://cdn.example/audio.mp3"
+        }
+        submit_response = Mock(status_code=200)
+        submit_response.json.return_value = {"id": "transcript-123"}
+        post.side_effect = [upload_response, submit_response]
+
+        poll_response = Mock(status_code=200)
+        poll_response.json.return_value = {"status": "error", "error": "bad audio"}
+        get.return_value = poll_response
+
+        transcriber = AssemblyAITranscription(temperature=0.3)
+        with self.assertRaisesRegex(Exception, "bad audio"):
+            transcriber.transcribe_audio(self.audio.name)
+
+    @patch("sapat.transcription.assemblyai.requests.post")
+    def test_raises_when_api_key_is_missing(self, post):
+        with patch.dict(os.environ, {"ASSEMBLYAI_API_KEY": ""}, clear=False):
+            transcriber = AssemblyAITranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "ASSEMBLYAI_API_KEY"):
+            transcriber.transcribe_audio(self.audio.name)
+        post.assert_not_called()
+
+    @patch("sapat.transcription.assemblyai.requests.get")
+    @patch("sapat.transcription.assemblyai.requests.post")
+    def test_times_out_when_transcript_remains_queued(self, post, get):
+        upload_response = Mock(status_code=200)
+        upload_response.json.return_value = {
+            "upload_url": "https://cdn.example/audio.mp3"
+        }
+        submit_response = Mock(status_code=200)
+        submit_response.json.return_value = {"id": "transcript-123"}
+        post.side_effect = [upload_response, submit_response]
+
+        poll_response = Mock(status_code=200)
+        poll_response.json.return_value = {"status": "queued"}
+        get.return_value = poll_response
+
+        transcriber = AssemblyAITranscription(
+            temperature=0.3,
+            poll_interval_seconds=0,
+            timeout_seconds=0,
+        )
+
+        with self.assertRaisesRegex(TimeoutError, "timed out"):
+            transcriber.transcribe_audio(self.audio.name)
+
+    @patch("sapat.transcription.assemblyai.requests.post")
+    def test_upload_http_errors_include_status_code(self, post):
+        upload_response = Mock(status_code=401, text="unauthorized")
+        post.return_value = upload_response
+
+        transcriber = AssemblyAITranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(RuntimeError, "401"):
+            transcriber.transcribe_audio(self.audio.name)
+
+    def test_accepts_uppercase_supported_extensions(self):
+        audio = tempfile.NamedTemporaryFile(suffix=".WAV", delete=False)
+        audio.write(b"fake audio")
+        audio.close()
+        self.addCleanup(os.unlink, audio.name)
+
+        transcriber = AssemblyAITranscription(temperature=0.3)
+
+        transcriber._validate_audio_file(audio.name)
+
+    @patch("sapat.transcription.assemblyai.requests.post")
+    def test_strips_trailing_slash_from_custom_endpoint(self, post):
+        upload_response = Mock(status_code=200)
+        upload_response.json.return_value = {
+            "upload_url": "https://cdn.example/audio.mp3"
+        }
+        post.return_value = upload_response
+
+        with patch.dict(
+            os.environ,
+            {"ASSEMBLYAI_API_ENDPOINT": "https://example.test/v2/"},
+            clear=False,
+        ):
+            transcriber = AssemblyAITranscription(temperature=0.3)
+
+        self.assertEqual(
+            transcriber._upload_audio(self.audio.name),
+            "https://cdn.example/audio.mp3",
+        )
+        post.assert_called_once_with(
+            "https://example.test/v2/upload",
+            headers={"Authorization": "test-key"},
+            data=ANY,
+        )
+
+    def test_requires_openai_settings_for_correction(self):
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "", "OPENAI_MODEL_NAME_CHAT": ""},
+            clear=False,
+        ):
+            transcriber = AssemblyAITranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "OPENAI_API_KEY"):
+            transcriber.generate_corrected_transcript(
+                self.audio.name,
+                temperature=0.7,
+                system_prompt="Fix punctuation.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,23 @@
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+
+
+class ScriptTest(unittest.TestCase):
+    @patch("sapat.script.AssemblyAITranscription")
+    def test_cli_routes_assemblyai_api_to_provider(self, provider):
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video:
+            result = runner.invoke(main, [video.name, "--api", "assemblyai"])
+
+        self.assertEqual(result.exit_code, 0)
+        provider.assert_called_once_with(temperature=0.3)
+        provider.return_value.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an AssemblyAI transcription backend available through `--api assemblyai`
- upload local audio to AssemblyAI, submit a transcript job, and poll until completion
- document AssemblyAI environment variables and usage
- cover provider success, text response, API-key validation, timeout handling, HTTP errors, custom endpoints, extension validation, correction preflight, and CLI routing

## Validation
- `. .venv/bin/activate && python -m unittest discover -s tests -v` -> 10 tests passed
- `. .venv/bin/activate && python -m compileall src tests`
- `. .venv/bin/activate && sapat --help`
- `. .venv/bin/activate && python -m pip check`
- `. .venv/bin/activate && python -m build --outdir /tmp/sapat-build-check-3`
- `uvx ruff check src tests`
- `uvx black --check src/sapat/transcription/assemblyai.py tests/test_assemblyai.py tests/test_script.py`
- `git diff --check`

Note: the three Continuous AI status contexts currently return `Agent encountered an error` with no GitHub Actions logs or PR review comments. The latest commit is clean locally and the PR remains mergeable.

This supports Daytona content issue daytonaio/content#13 by adding another concrete Sapat transcription provider for the guide to reference.