### PR TITLE
Add Google Cloud Speech-to-Text provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Google Cloud Speech-to-Text APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Google Cloud Speech-to-Text APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Google Cloud Speech-to-Text API
 
 ## Installation
 
@@ -53,6 +54,13 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Google Cloud Speech-to-Text
+   GOOGLE_SPEECH_API_KEY=your_google_speech_api_key_here
+   GOOGLE_SPEECH_API_ENDPOINT=https://speech.googleapis.com/v1p1beta1/speech:recognize
+   GOOGLE_SPEECH_MODEL=latest_long
+   GOOGLE_SPEECH_LANGUAGE=en-US
+   GOOGLE_SPEECH_USE_ENHANCED=false
    ```
 
 ## Building and Installing the Package
@@ -115,6 +123,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api google` for Google Cloud Speech-to-Text API
 
 Example:
 
@@ -129,7 +138,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Google Cloud Speech-to-Text). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.google import GoogleSpeechTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'google'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'google')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "google":
+        transcriber = GoogleSpeechTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/google.py
+++ b/src/sapat/transcription/google.py
@@ -1,0 +1,97 @@
+import base64
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class GoogleSpeechTranscription(TranscriptionBase):
+    """
+    Google Cloud Speech-to-Text REST API implementation.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        self.api_key = os.getenv("GOOGLE_SPEECH_API_KEY")
+        self.endpoint = os.getenv(
+            "GOOGLE_SPEECH_API_ENDPOINT",
+            "https://speech.googleapis.com/v1p1beta1/speech:recognize",
+        )
+        self.model = os.getenv("GOOGLE_SPEECH_MODEL", "latest_long")
+        self.default_language = os.getenv("GOOGLE_SPEECH_LANGUAGE", "en-US")
+        self.use_enhanced = os.getenv("GOOGLE_SPEECH_USE_ENHANCED", "false").lower() == "true"
+        self.temperature = temperature
+        self.response_format = response_format
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        if not self.api_key:
+            raise ValueError("GOOGLE_SPEECH_API_KEY is required for Google transcription.")
+
+        language = kwargs.get("language") or self.default_language
+        response_format = kwargs.get("response_format", self.response_format)
+
+        with open(audio_file, "rb") as f:
+            audio_content = base64.b64encode(f.read()).decode("utf-8")
+
+        request_body = {
+            "config": {
+                "encoding": "MP3",
+                "languageCode": self._normalize_language(language),
+                "enableAutomaticPunctuation": True,
+                "model": kwargs.get("model", self.model),
+                "useEnhanced": kwargs.get("use_enhanced", self.use_enhanced),
+            },
+            "audio": {
+                "content": audio_content,
+            },
+        }
+
+        response = requests.post(
+            self.endpoint,
+            params={"key": self.api_key},
+            json=request_body,
+            timeout=120,
+        )
+
+        if response.status_code != 200:
+            raise Exception(f"Transcription failed: {response.text}")
+
+        payload = response.json()
+        text = self._extract_transcript(payload)
+
+        if response_format in ["json", "verbose_json"]:
+            return {
+                "text": text,
+                "results": payload.get("results", []),
+            }
+        return text
+
+    @staticmethod
+    def _normalize_language(language: str):
+        language_map = {
+            "en": "en-US",
+            "es": "es-ES",
+            "fr": "fr-FR",
+            "de": "de-DE",
+            "pt": "pt-BR",
+        }
+        return language_map.get(language, language)
+
+    @staticmethod
+    def _extract_transcript(payload):
+        transcripts = []
+        for result in payload.get("results", []):
+            alternatives = result.get("alternatives", [])
+            if alternatives:
+                transcript = alternatives[0].get("transcript", "").strip()
+                if transcript:
+                    transcripts.append(transcript)
+        return "\n".join(transcripts)
+
+    @staticmethod
+    def generate_corrected_transcript(audio_file, temperature, prompt):
+        raise NotImplementedError("Correction not implemented for Google Speech-to-Text.")

--- a/tests/test_google_transcription.py
+++ b/tests/test_google_transcription.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.google import GoogleSpeechTranscription
+
+
+class GoogleSpeechTranscriptionTest(unittest.TestCase):
+    @patch.dict(os.environ, {"GOOGLE_SPEECH_API_KEY": "test-key"}, clear=False)
+    @patch("sapat.transcription.google.requests.post")
+    def test_transcribe_audio_posts_google_request_and_extracts_text(self, post_mock):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "results": [
+                {"alternatives": [{"transcript": "first segment"}]},
+                {"alternatives": [{"transcript": "second segment"}]},
+            ]
+        }
+        post_mock.return_value = response
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as audio_file:
+            audio_file.write(b"fake audio")
+            audio_path = audio_file.name
+
+        try:
+            transcriber = GoogleSpeechTranscription(temperature=0.3)
+            result = transcriber.transcribe_audio(
+                audio_path,
+                language="en",
+                response_format="text",
+            )
+        finally:
+            Path(audio_path).unlink(missing_ok=True)
+
+        self.assertEqual(result, "first segment\nsecond segment")
+
+        _, kwargs = post_mock.call_args
+        self.assertEqual(kwargs["params"], {"key": "test-key"})
+        self.assertEqual(kwargs["json"]["config"]["encoding"], "MP3")
+        self.assertEqual(kwargs["json"]["config"]["languageCode"], "en-US")
+        self.assertEqual(kwargs["json"]["config"]["model"], "latest_long")
+        self.assertIn("content", kwargs["json"]["audio"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a Google Cloud Speech-to-Text provider so Sapat can transcribe via `--api google` in addition to Azure, Groq, and OpenAI.

Changes:
- Adds `GoogleSpeechTranscription` using the Google Speech-to-Text REST API with `GOOGLE_SPEECH_*` environment configuration.
- Uses the `v1p1beta1` recognize endpoint because Sapat converts input media to MP3 before transcription.
- Wires the CLI to accept `--api google`.
- Documents the Google configuration in the README.
- Adds a focused mocked unit test for request construction and transcript extraction.

Validation:
- `.\.venv\Scripts\python -m unittest tests.test_google_transcription -v`
- `.\.venv\Scripts\python -m py_compile src\sapat\script.py src\sapat\transcription\google.py src\sapat\transcription\base.py src\sapat\transcription\openai.py src\sapat\transcription\groq.py src\sapat\transcription\azure.py tests\test_google_transcription.py`
- `git diff --check`

Related Daytona content bounty: daytonaio/content#13