### PR TITLE
feat: add ElevenLabs transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, ElevenLabs, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, ElevenLabs, Groq, and OpenAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -16,6 +16,7 @@ This tool automates the process of transcribing video files using multiple trans
 - ffmpeg installed and available in the system PATH
 - API access for one or more supported services:
   - Azure OpenAI API
+  - ElevenLabs API
   - Groq Cloud API
   - OpenAI API
 
@@ -47,6 +48,11 @@ This tool automates the process of transcribing video files using multiple trans
    GROQCLOUD_MODEL=whisper-large-v3-turbo
    GROQCLOUD_API_ENDPOINT=https://api.groq.com/openai/v1/audio/transcriptions
    GROQCLOUD_MODEL_NAME_CHAT=llama3-8b-8192
+
+   # ElevenLabs
+   ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
+   ELEVENLABS_MODEL=scribe_v2
+   ELEVENLABS_API_ENDPOINT=https://api.elevenlabs.io/v1/speech-to-text
 
    # OpenAI
    OPENAI_API_KEY=your_openai_api_key_here
@@ -113,6 +119,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
 - `--quality`: Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M').
 - `--api`: Specify the API to use for transcription.
    - `--api azure` for Azure OpenAI API
+   - `--api elevenlabs` for ElevenLabs API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
 
@@ -122,6 +129,12 @@ Example:
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
 ```
 
+ElevenLabs example:
+
+```
+sapat my_video.mp4 --quality H --language en --api elevenlabs
+```
+
 - If a file is provided, it will process that single file.
 - If a directory is provided, it will process all `.mp4` files in that directory.
 
@@ -129,7 +142,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, ElevenLabs, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -21,6 +21,12 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     # Initialize the correct transcription object
     input_path = Path(input_path)
+    if api.lower() == "elevenlabs" and correct:
+        click.echo(
+            "Transcript correction is not supported for ElevenLabs. "
+            "Run without --correct or choose openai, groq, or azure."
+        )
+        return
 
     # Handle file processing based on API choice
     if api.lower() == "groq":

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.elevenlabs import ElevenLabsTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'elevenlabs'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'elevenlabs')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "elevenlabs":
+        transcriber = ElevenLabsTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/elevenlabs.py
+++ b/src/sapat/transcription/elevenlabs.py
@@ -1,0 +1,83 @@
+import os
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class ElevenLabsTranscription(TranscriptionBase):
+    """
+    ElevenLabs Scribe implementation for transcription.
+    """
+
+    def __init__(self, temperature: float):
+        self.api_key = os.getenv("ELEVENLABS_API_KEY")
+        self.model = os.getenv("ELEVENLABS_MODEL", "scribe_v2")
+        self.endpoint = os.getenv(
+            "ELEVENLABS_API_ENDPOINT",
+            "https://api.elevenlabs.io/v1/speech-to-text",
+        )
+        self.temperature = temperature
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using the ElevenLabs Speech to Text API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict: The transcription result.
+        """
+        self._validate_audio_file(audio_file)
+
+        data = {
+            "model_id": kwargs.get("model", self.model),
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        language = kwargs.get("language")
+        if language:
+            data["language_code"] = language
+
+        headers = {
+            "xi-api-key": self.api_key,
+        }
+
+        audio_path = Path(audio_file)
+        with open(audio_file, "rb") as f:
+            files = {
+                "file": (audio_path.name, f, "audio/mpeg"),
+            }
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                data=data,
+                files=files,
+                timeout=120,
+            )
+
+        if response.status_code == 200:
+            return response.json()
+
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not self.api_key:
+            raise ValueError("ELEVENLABS_API_KEY must be set in the environment.")
+
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".m4a", ".ogg"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/src/sapat/transcription/elevenlabs.py
+++ b/src/sapat/transcription/elevenlabs.py
@@ -1,4 +1,5 @@
 import os
+import mimetypes
 from pathlib import Path
 
 import requests
@@ -8,6 +9,9 @@ from .base import TranscriptionBase
 
 
 load_dotenv(".env")
+
+
+SUPPORTED_EXTENSIONS = (".mp3", ".wav", ".flac", ".m4a", ".ogg")
 
 
 class ElevenLabsTranscription(TranscriptionBase):
@@ -51,9 +55,10 @@ class ElevenLabsTranscription(TranscriptionBase):
         }
 
         audio_path = Path(audio_file)
-        with open(audio_file, "rb") as f:
+        content_type = mimetypes.guess_type(audio_path.name)[0] or "application/octet-stream"
+        with audio_path.open("rb") as f:
             files = {
-                "file": (audio_path.name, f, "audio/mpeg"),
+                "file": (audio_path.name, f, content_type),
             }
             response = requests.post(
                 self.endpoint,
@@ -66,7 +71,9 @@ class ElevenLabsTranscription(TranscriptionBase):
         if response.status_code == 200:
             return response.json()
 
-        raise Exception(f"Transcription failed: {response.text}")
+        raise Exception(
+            f"Transcription failed with status {response.status_code}: {response.text}"
+        )
 
     def _validate_audio_file(self, audio_file: str):
         if not self.api_key:
@@ -75,9 +82,9 @@ class ElevenLabsTranscription(TranscriptionBase):
         if not os.path.exists(audio_file):
             raise ValueError(f"File {audio_file} does not exist.")
 
-        valid_extensions = [".mp3", ".wav", ".flac", ".m4a", ".ogg"]
-        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+        extension = Path(audio_file).suffix.lower()
+        if extension not in SUPPORTED_EXTENSIONS:
             raise ValueError(
                 f"Unsupported audio file format: {audio_file}. "
-                f"Supported formats are {valid_extensions}."
+                f"Supported formats are {list(SUPPORTED_EXTENSIONS)}."
             )

--- a/tests/test_elevenlabs.py
+++ b/tests/test_elevenlabs.py
@@ -1,0 +1,69 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.elevenlabs import ElevenLabsTranscription
+
+
+class ElevenLabsTranscriptionTests(unittest.TestCase):
+    def test_transcribe_audio_sends_expected_multipart_request(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"text": "Hello from Sapat"}
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"fake audio")
+            audio.flush()
+
+            with patch.dict(
+                os.environ,
+                {
+                    "ELEVENLABS_API_KEY": "test-key",
+                    "ELEVENLABS_MODEL": "scribe_v2",
+                    "ELEVENLABS_API_ENDPOINT": "https://example.test/speech-to-text",
+                },
+            ):
+                transcriber = ElevenLabsTranscription(temperature=0.2)
+
+            with patch(
+                "sapat.transcription.elevenlabs.requests.post",
+                return_value=response,
+            ) as post:
+                result = transcriber.transcribe_audio(audio.name, language="en")
+
+        self.assertEqual(result, {"text": "Hello from Sapat"})
+        post.assert_called_once()
+
+        _, kwargs = post.call_args
+        self.assertEqual(kwargs["headers"], {"xi-api-key": "test-key"})
+        self.assertEqual(
+            kwargs["data"],
+            {
+                "model_id": "scribe_v2",
+                "temperature": 0.2,
+                "language_code": "en",
+            },
+        )
+        self.assertEqual(kwargs["timeout"], 120)
+        self.assertIn("file", kwargs["files"])
+
+    def test_validate_audio_file_requires_api_key(self):
+        with patch.dict(os.environ, {"ELEVENLABS_API_KEY": ""}):
+            transcriber = ElevenLabsTranscription(temperature=0.2)
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            with self.assertRaisesRegex(ValueError, "ELEVENLABS_API_KEY"):
+                transcriber.transcribe_audio(audio.name)
+
+    def test_validate_audio_file_rejects_unsupported_extension(self):
+        with patch.dict(os.environ, {"ELEVENLABS_API_KEY": "test-key"}):
+            transcriber = ElevenLabsTranscription(temperature=0.2)
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as audio:
+            with self.assertRaisesRegex(ValueError, "Unsupported audio file"):
+                transcriber.transcribe_audio(audio.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_elevenlabs.py
+++ b/tests/test_elevenlabs.py
@@ -47,6 +47,29 @@ class ElevenLabsTranscriptionTests(unittest.TestCase):
         )
         self.assertEqual(kwargs["timeout"], 120)
         self.assertIn("file", kwargs["files"])
+        self.assertEqual(kwargs["files"]["file"][2], "audio/mpeg")
+
+    def test_transcribe_audio_reports_provider_failure_status(self):
+        response = Mock()
+        response.status_code = 401
+        response.text = "invalid api key"
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"fake audio")
+            audio.flush()
+
+            with patch.dict(os.environ, {"ELEVENLABS_API_KEY": "test-key"}):
+                transcriber = ElevenLabsTranscription(temperature=0.2)
+
+            with patch(
+                "sapat.transcription.elevenlabs.requests.post",
+                return_value=response,
+            ):
+                with self.assertRaisesRegex(
+                    Exception,
+                    "Transcription failed with status 401",
+                ):
+                    transcriber.transcribe_audio(audio.name)
 
     def test_validate_audio_file_requires_api_key(self):
         with patch.dict(os.environ, {"ELEVENLABS_API_KEY": ""}):


### PR DESCRIPTION
## Summary

- Add an ElevenLabs Scribe transcription provider.
- Add `--api elevenlabs` to the CLI provider choices.
- Document the required ElevenLabs environment variables and usage example.
- Add unit tests for request shape, missing API key handling, and unsupported file validation.

## Validation

- `.venv/bin/python -m unittest discover -s tests -v`
- `python3 -m compileall src tests`
- `git diff --check`
- `.venv/bin/sapat --help`