### PR TITLE
Add Mistral transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+MISTRAL_API_KEY=
+MISTRAL_MODEL=voxtral-mini-latest
+MISTRAL_API_ENDPOINT=https://api.mistral.ai/v1/audio/transcriptions
+MISTRAL_MODEL_NAME_CHAT=mistral-small-latest
+MISTRAL_CHAT_API_ENDPOINT=https://api.mistral.ai/v1/chat/completions

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Mistral APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Mistral APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Mistral API
 
 ## Installation
 
@@ -53,6 +54,13 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Mistral
+   MISTRAL_API_KEY=your_mistral_api_key_here
+   MISTRAL_MODEL=voxtral-mini-latest
+   MISTRAL_API_ENDPOINT=https://api.mistral.ai/v1/audio/transcriptions
+   MISTRAL_MODEL_NAME_CHAT=mistral-small-latest
+   MISTRAL_CHAT_API_ENDPOINT=https://api.mistral.ai/v1/chat/completions
    ```
 
 ## Building and Installing the Package
@@ -115,11 +123,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api mistral` for Mistral API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+To use Mistral's Voxtral transcription endpoint:
+
+```
+sapat my_video.mp4 --quality H --language es --api mistral
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +144,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Mistral). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.mistral import MistralTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'mistral'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'mistral')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "mistral":
+        transcriber = MistralTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/mistral.py
+++ b/src/sapat/transcription/mistral.py
@@ -1,0 +1,138 @@
+import os
+import requests
+from dotenv import load_dotenv
+from .base import TranscriptionBase
+
+# Load environment variables
+load_dotenv(".env")
+
+
+class MistralTranscription(TranscriptionBase):
+    """
+    Mistral API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the MistralTranscription class.
+
+        Parameters:
+        - temperature (float): Default temperature value for transcription.
+        - response_format (str): Default response format for transcription.
+        """
+        self.api_key = os.getenv("MISTRAL_API_KEY")
+        self.model = os.getenv("MISTRAL_MODEL", "voxtral-mini-latest")
+        self.endpoint = os.getenv(
+            "MISTRAL_API_ENDPOINT",
+            "https://api.mistral.ai/v1/audio/transcriptions",
+        )
+        self.model_name_chat = os.getenv("MISTRAL_MODEL_NAME_CHAT", "mistral-small-latest")
+        self.chat_endpoint = os.getenv(
+            "MISTRAL_CHAT_API_ENDPOINT",
+            "https://api.mistral.ai/v1/chat/completions",
+        )
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Mistral's audio transcription API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_audio_file(audio_file)
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        data = {
+            "model": kwargs.get("model", self.model),
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        if "language" in kwargs:
+            data["language"] = kwargs["language"]
+
+        # Mistral exposes context_bias instead of OpenAI's prompt parameter.
+        if kwargs.get("prompt"):
+            data["context_bias"] = kwargs["prompt"]
+
+        with open(audio_file, "rb") as f:
+            files = {"file": f}
+            response = requests.post(self.endpoint, headers=headers, data=data, files=files)
+
+        if response.status_code == 200:
+            result = response.json()
+            if self.response_format in ["json", "verbose_json"]:
+                return result
+            return result.get("text", "")
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def generate_corrected_transcript(self, audio_file: str, temperature: float, system_prompt: str):
+        """
+        Uses Mistral's chat API to correct the transcription text.
+
+        Parameters:
+        - audio_file (str): Path to the audio file for transcription.
+        - temperature (float): The sampling temperature for the chat API.
+        - system_prompt (str): The system prompt to guide the assistant.
+
+        Returns:
+        - str: The corrected transcription.
+        """
+        transcription = self.transcribe_audio(audio_file)
+        transcription_text = transcription.get("text", "") if isinstance(transcription, dict) else transcription
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.model_name_chat,
+            "temperature": temperature,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": system_prompt,
+                },
+                {
+                    "role": "user",
+                    "content": transcription_text,
+                },
+            ],
+        }
+        response = requests.post(self.chat_endpoint, headers=headers, json=payload)
+
+        if response.status_code == 200:
+            result = response.json()
+            return result["choices"][0]["message"]["content"]
+        raise Exception(f"Transcript correction failed: {response.text}")
+
+    def _validate_audio_file(self, audio_file: str):
+        """
+        Validates the audio file for size and format.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+
+        Raises:
+        - Exception: If the file is invalid.
+        """
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [".mp3", ".wav", ".flac"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}."
+            )

--- a/tests/test_mistral_transcription.py
+++ b/tests/test_mistral_transcription.py
@@ -1,0 +1,83 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sapat.transcription.mistral import MistralTranscription
+
+
+class MistralTranscriptionTest(unittest.TestCase):
+    def make_audio_file(self):
+        audio = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        audio.write(b"fake audio")
+        audio.close()
+        self.addCleanup(lambda: os.path.exists(audio.name) and os.unlink(audio.name))
+        return audio.name
+
+    @patch.dict(
+        os.environ,
+        {
+            "MISTRAL_API_KEY": "test-key",
+            "MISTRAL_MODEL": "voxtral-mini-latest",
+            "MISTRAL_API_ENDPOINT": "https://api.mistral.ai/v1/audio/transcriptions",
+            "MISTRAL_MODEL_NAME_CHAT": "mistral-small-latest",
+            "MISTRAL_CHAT_API_ENDPOINT": "https://api.mistral.ai/v1/chat/completions",
+        },
+    )
+    @patch("sapat.transcription.mistral.requests.post")
+    def test_transcribe_audio_sends_mistral_request(self, post):
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"text": "Hello from Mistral"}
+        post.return_value = response
+        transcriber = MistralTranscription(temperature=0.2)
+
+        result = transcriber.transcribe_audio(
+            self.make_audio_file(),
+            language="en",
+            prompt="Product names: Daytona, Sapat",
+        )
+
+        self.assertEqual(result, {"text": "Hello from Mistral"})
+        _, kwargs = post.call_args
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(kwargs["data"]["model"], "voxtral-mini-latest")
+        self.assertEqual(kwargs["data"]["language"], "en")
+        self.assertEqual(kwargs["data"]["context_bias"], "Product names: Daytona, Sapat")
+        self.assertIn("file", kwargs["files"])
+
+    @patch.dict(
+        os.environ,
+        {
+            "MISTRAL_API_KEY": "test-key",
+            "MISTRAL_MODEL": "voxtral-mini-latest",
+            "MISTRAL_API_ENDPOINT": "https://api.mistral.ai/v1/audio/transcriptions",
+            "MISTRAL_MODEL_NAME_CHAT": "mistral-small-latest",
+            "MISTRAL_CHAT_API_ENDPOINT": "https://api.mistral.ai/v1/chat/completions",
+        },
+    )
+    @patch("sapat.transcription.mistral.requests.post")
+    def test_generate_corrected_transcript_uses_chat_endpoint(self, post):
+        transcription_response = MagicMock(status_code=200)
+        transcription_response.json.return_value = {"text": "raw transcript"}
+        chat_response = MagicMock(status_code=200)
+        chat_response.json.return_value = {
+            "choices": [{"message": {"content": "corrected transcript"}}]
+        }
+        post.side_effect = [transcription_response, chat_response]
+        transcriber = MistralTranscription(temperature=0.2)
+
+        result = transcriber.generate_corrected_transcript(
+            self.make_audio_file(),
+            0.1,
+            "Correct spelling only.",
+        )
+
+        self.assertEqual(result, "corrected transcript")
+        chat_call = post.call_args_list[1]
+        self.assertEqual(chat_call.args[0], "https://api.mistral.ai/v1/chat/completions")
+        self.assertEqual(chat_call.kwargs["json"]["model"], "mistral-small-latest")
+        self.assertEqual(chat_call.kwargs["json"]["messages"][1]["content"], "raw transcript")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Mistral Voxtral transcription provider using the audio/transcriptions endpoint
- expose it through --api mistral
- document Mistral environment variables and usage in README/.env.example
- add unit tests for request construction and the optional correction flow

## Validation
- py -m compileall src tests
- PYTHONPATH=src py -m sapat.script --help
- PYTHONPATH=src py -m unittest discover -s tests
- py -m build
- git diff --check

This is a companion implementation for daytonaio/content#13.