### PR TITLE
feat: add Fireworks transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+FIREWORKS_API_KEY=
+FIREWORKS_MODEL=whisper-v3
+FIREWORKS_API_ENDPOINT=https://audio-prod.api.fireworks.ai/v1/audio/transcriptions
+FIREWORKS_CHAT_BASE_URL=https://api.fireworks.ai/inference/v1
+FIREWORKS_MODEL_NAME_CHAT=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: pip install --upgrade pip && pip install -e ".[dev]"
+
+      - name: Test
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Fireworks AI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Fireworks AI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Fireworks AI API
 
 ## Installation
 
@@ -53,6 +54,13 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Fireworks AI
+   FIREWORKS_API_KEY=your_fireworks_api_key_here
+   FIREWORKS_MODEL=whisper-v3
+   FIREWORKS_API_ENDPOINT=https://audio-prod.api.fireworks.ai/v1/audio/transcriptions
+   FIREWORKS_CHAT_BASE_URL=https://api.fireworks.ai/inference/v1
+   FIREWORKS_MODEL_NAME_CHAT=accounts/fireworks/models/llama-v3p1-8b-instruct
    ```
 
 ## Building and Installing the Package
@@ -115,11 +123,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api fireworks` for Fireworks AI Audio API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Fireworks example:
+
+```
+sapat my_video.mp4 --quality M --language en --api fireworks
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +144,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Fireworks AI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,16 @@ dependencies = [
     "groq>=0.13.1"
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+]
+
 [project.scripts]
 sapat = "sapat.script:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [build-system]
 requires = ["wheel", "setuptools>=61.0"] # Ensure setuptools is recent enough

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.fireworks import FireworksTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'fireworks'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'fireworks')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "fireworks":
+        transcriber = FireworksTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/fireworks.py
+++ b/src/sapat/transcription/fireworks.py
@@ -1,0 +1,147 @@
+import os
+import requests
+from openai import OpenAI
+from dotenv import load_dotenv
+from .base import TranscriptionBase
+
+# Load environment variables
+load_dotenv(".env")
+
+
+class FireworksTranscription(TranscriptionBase):
+    """
+    Fireworks AI Audio API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the FireworksTranscription class.
+
+        Parameters:
+        - temperature (float): Default temperature value for transcription.
+        - response_format (str): Default response format for transcription.
+        """
+        self.api_key = os.getenv('FIREWORKS_API_KEY')
+        self.model = os.getenv('FIREWORKS_MODEL', 'whisper-v3')
+        self.endpoint = os.getenv('FIREWORKS_API_ENDPOINT') or self._default_endpoint_for_model(self.model)
+        self.chat_base_url = os.getenv('FIREWORKS_CHAT_BASE_URL', 'https://api.fireworks.ai/inference/v1')
+        self.model_name_chat = os.getenv('FIREWORKS_MODEL_NAME_CHAT')
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = 1024
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using the Fireworks AI Audio API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_configuration()
+        self._validate_audio_file(audio_file)
+
+        data = {
+            "model": kwargs.get("model", self.model),
+            "response_format": kwargs.get("response_format", self.response_format),
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        if kwargs.get("language"):
+            data["language"] = kwargs["language"]
+        if kwargs.get("prompt"):
+            data["prompt"] = kwargs["prompt"]
+
+        headers = {
+            "Authorization": self.api_key,
+        }
+
+        with open(audio_file, 'rb') as f:
+            files = {'file': f}
+            response = requests.post(self.endpoint, headers=headers, data=data, files=files)
+
+        if response.status_code == 200:
+            if data["response_format"] in ["json", "verbose_json"]:
+                return response.json()
+            return response.text
+        else:
+            raise Exception(f"Transcription failed: {response.text}")
+
+    def generate_corrected_transcript(self, audio_file: str, temperature: float, system_prompt: str):
+        """
+        Uses Fireworks' OpenAI-compatible chat API to correct the transcription text.
+
+        Parameters:
+        - audio_file (str): Path to the audio file for transcription.
+        - temperature (float): The sampling temperature for the chat API.
+        - system_prompt (str): The system prompt to guide the assistant.
+
+        Returns:
+        - str: The corrected transcription.
+        """
+        self._validate_configuration()
+
+        if not self.model_name_chat:
+            raise ValueError("FIREWORKS_MODEL_NAME_CHAT must be set to use --correct with Fireworks.")
+
+        client = OpenAI(
+            api_key=self.api_key,
+            base_url=self.chat_base_url,
+        )
+
+        transcription = self.transcribe_audio(audio_file)
+        transcription_text = transcription.get('text', '') if isinstance(transcription, dict) else transcription
+
+        response = client.chat.completions.create(
+            model=self.model_name_chat,
+            temperature=temperature,
+            messages=[
+                {
+                    "role": "system",
+                    "content": system_prompt
+                },
+                {
+                    "role": "user",
+                    "content": transcription_text
+                }
+            ]
+        )
+        return response.choices[0].message.content
+
+    def _validate_configuration(self):
+        if not self.api_key:
+            raise ValueError("FIREWORKS_API_KEY must be set.")
+        if not self.endpoint:
+            raise ValueError("FIREWORKS_API_ENDPOINT must be set.")
+        if not self.model:
+            raise ValueError("FIREWORKS_MODEL must be set.")
+
+    def _validate_audio_file(self, audio_file: str):
+        """
+        Validates the audio file for size and format.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+
+        Raises:
+        - Exception: If the file is invalid.
+        """
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = ['.mp3', '.wav', '.flac']
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}.")
+
+    @staticmethod
+    def _default_endpoint_for_model(model: str):
+        if model == 'whisper-v3-turbo':
+            return 'https://audio-turbo.api.fireworks.ai/v1/audio/transcriptions'
+        return 'https://audio-prod.api.fireworks.ai/v1/audio/transcriptions'

--- a/tests/test_fireworks.py
+++ b/tests/test_fireworks.py
@@ -1,0 +1,133 @@
+from unittest.mock import MagicMock, patch
+
+
+def test_default_endpoint_whisper_v3_turbo(monkeypatch):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw_test_key")
+    monkeypatch.setenv("FIREWORKS_MODEL", "whisper-v3-turbo")
+    monkeypatch.delenv("FIREWORKS_API_ENDPOINT", raising=False)
+
+    from importlib import reload
+    import sapat.transcription.fireworks as fireworks
+
+    reload(fireworks)
+    svc = fireworks.FireworksTranscription(temperature=0.0)
+
+    assert (
+        svc.endpoint
+        == "https://audio-turbo.api.fireworks.ai/v1/audio/transcriptions"
+    )
+
+
+def test_default_endpoint_non_turbo(monkeypatch):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw_test_key")
+    monkeypatch.setenv("FIREWORKS_MODEL", "whisper-v3")
+    monkeypatch.delenv("FIREWORKS_API_ENDPOINT", raising=False)
+
+    from importlib import reload
+    import sapat.transcription.fireworks as fireworks
+
+    reload(fireworks)
+    svc = fireworks.FireworksTranscription(temperature=0.0)
+
+    assert svc.endpoint == "https://audio-prod.api.fireworks.ai/v1/audio/transcriptions"
+
+
+def test_transcribe_audio_json_success(tmp_path, monkeypatch):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw_test_key")
+    monkeypatch.setenv("FIREWORKS_MODEL", "whisper-v3")
+    monkeypatch.setenv(
+        "FIREWORKS_API_ENDPOINT",
+        "https://audio-prod.api.fireworks.ai/v1/audio/transcriptions",
+    )
+
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"fake-mp3-bytes-for-test")
+
+    from importlib import reload
+    import sapat.transcription.fireworks as fireworks
+
+    reload(fireworks)
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {"text": "hello"}
+
+    with patch.object(fireworks.requests, "post", return_value=fake_resp) as post:
+        svc = fireworks.FireworksTranscription(temperature=0.2)
+        out = svc.transcribe_audio(str(audio))
+
+    assert out == {"text": "hello"}
+    args, kwargs = post.call_args
+    assert kwargs["headers"]["Authorization"] == "fw_test_key"
+    payload = kwargs["data"]
+    assert payload["response_format"] == "json"
+
+
+def test_transcribe_raises_on_missing_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+    monkeypatch.setenv("FIREWORKS_MODEL", "whisper-v3")
+    monkeypatch.delenv("FIREWORKS_API_ENDPOINT", raising=False)
+
+    from importlib import reload
+    import sapat.transcription.fireworks as fireworks
+
+    reload(fireworks)
+
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"x")
+
+    svc = fireworks.FireworksTranscription(temperature=0.0)
+    try:
+        svc.transcribe_audio(str(audio))
+    except ValueError as e:
+        assert "FIREWORKS_API_KEY" in str(e)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_transcribe_rejects_bad_extension(monkeypatch, tmp_path):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw_test_key")
+    monkeypatch.setenv("FIREWORKS_MODEL", "whisper-v3")
+    monkeypatch.delenv("FIREWORKS_API_ENDPOINT", raising=False)
+
+    from importlib import reload
+    import sapat.transcription.fireworks as fireworks
+
+    reload(fireworks)
+
+    bad = tmp_path / "audio.m4a"
+    bad.write_bytes(b"x")
+
+    svc = fireworks.FireworksTranscription(temperature=0.0)
+
+    try:
+        svc.transcribe_audio(str(bad))
+    except ValueError as e:
+        assert "Unsupported audio file format" in str(e)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_corrected_transcript_requires_chat_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw_test_key")
+    monkeypatch.setenv("FIREWORKS_MODEL", "whisper-v3")
+    monkeypatch.delenv("FIREWORKS_API_ENDPOINT", raising=False)
+    monkeypatch.delenv("FIREWORKS_MODEL_NAME_CHAT", raising=False)
+
+    from importlib import reload
+    import sapat.transcription.fireworks as fireworks
+
+    reload(fireworks)
+
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"x")
+
+    svc = fireworks.FireworksTranscription(temperature=0.0)
+
+    try:
+        svc.generate_corrected_transcript(str(audio), 0.5, "prompt")
+    except ValueError as e:
+        assert "FIREWORKS_MODEL_NAME_CHAT" in str(e)
+    else:
+        raise AssertionError("expected ValueError")
+

--- a/tests/test_fireworks.py
+++ b/tests/test_fireworks.py
@@ -108,6 +108,35 @@ def test_transcribe_rejects_bad_extension(monkeypatch, tmp_path):
         raise AssertionError("expected ValueError")
 
 
+def test_transcribe_audio_raises_on_http_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw_test_key")
+    monkeypatch.setenv("FIREWORKS_MODEL", "whisper-v3")
+    monkeypatch.delenv("FIREWORKS_API_ENDPOINT", raising=False)
+
+    audio = tmp_path / "clip.mp3"
+    audio.write_bytes(b"x")
+
+    from importlib import reload
+    import sapat.transcription.fireworks as fireworks
+
+    reload(fireworks)
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 400
+    fake_resp.text = "bad request body"
+
+    with patch.object(fireworks.requests, "post", return_value=fake_resp):
+        svc = fireworks.FireworksTranscription(temperature=0.0)
+
+        try:
+            svc.transcribe_audio(str(audio))
+        except Exception as e:
+            assert "Transcription failed" in str(e)
+            assert "bad request body" in str(e)
+        else:
+            raise AssertionError("expected Exception")
+
+
 def test_corrected_transcript_requires_chat_model(monkeypatch, tmp_path):
     monkeypatch.setenv("FIREWORKS_API_KEY", "fw_test_key")
     monkeypatch.setenv("FIREWORKS_MODEL", "whisper-v3")


### PR DESCRIPTION
## Scope
Add Fireworks AI as a new transcription backend in Sapat.

## Notes
- Adds new fireworks provider implementation with env-driven config.
- Wires --api fireworks into CLI.
- Documents Fireworks env vars and usage examples.

## Validation
- python3 -m compileall src passes locally.


## CI Failures Unresolved
- Continuous AI: Improve Test Coverage - Agent encountered an error. Check URL: https://hub.continue.dev/inbox/pr/nibzard/sapat/17?taskId=52d262ac-eb0a-4272-a575-ff92f558881a&utm_source=github_pr&utm_medium=check_status&utm_campaign=continue_tasks
- Continuous AI: Accessibility Fix Agent - still pending (external agent). Check URL: https://hub.continue.dev/inbox/pr/nibzard/sapat/17?taskId=7548e9f8-6e82-48d7-a1f3-aca3e1792910&utm_source=github_pr&utm_medium=check_status&utm_campaign=continue_tasks
- Continuous AI: Anti-Slop - still pending (external agent). Check URL: https://hub.continue.dev/inbox/pr/nibzard/sapat/17?taskId=d82fe18d-29e3-4112-bd47-9f3491357d7b&utm_source=github_pr&utm_medium=check_status&utm_campaign=continue_tasks
