### PR TITLE
Add Speechmatics transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+SPEECHMATICS_API_KEY=
+SPEECHMATICS_API_ENDPOINT=https://asr.api.speechmatics.com/v2/jobs
+SPEECHMATICS_OPERATING_POINT=standard

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Speechmatics APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Speechmatics APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Speechmatics API
 
 ## Installation
 
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Speechmatics
+   SPEECHMATICS_API_KEY=your_speechmatics_api_key_here
+   SPEECHMATICS_API_ENDPOINT=https://asr.api.speechmatics.com/v2/jobs
+   SPEECHMATICS_OPERATING_POINT=standard
    ```
 
 ## Building and Installing the Package
@@ -115,6 +121,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api speechmatics` for Speechmatics Batch API
 
 Example:
 
@@ -129,7 +136,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Speechmatics). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.speechmatics import SpeechmaticsTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'speechmatics'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'speechmatics')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "speechmatics":
+        transcriber = SpeechmaticsTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/speechmatics.py
+++ b/src/sapat/transcription/speechmatics.py
@@ -1,0 +1,127 @@
+import json
+import os
+import time
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class SpeechmaticsTranscription(TranscriptionBase):
+    """
+    Speechmatics Batch API implementation for transcription.
+    """
+
+    TERMINAL_STATUSES = {"done", "rejected", "deleted", "expired"}
+
+    def __init__(
+        self,
+        temperature: float,
+        poll_interval_seconds: float = 5,
+        max_poll_seconds: float = 1800,
+    ):
+        self.api_key = os.getenv("SPEECHMATICS_API_KEY")
+        self.endpoint = os.getenv(
+            "SPEECHMATICS_API_ENDPOINT",
+            "https://asr.api.speechmatics.com/v2/jobs",
+        ).rstrip("/")
+        self.operating_point = os.getenv("SPEECHMATICS_OPERATING_POINT", "standard")
+        self.temperature = temperature
+        self.poll_interval_seconds = poll_interval_seconds
+        self.max_poll_seconds = max_poll_seconds
+        self.max_file_size_mb = 2048
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using the Speechmatics Batch API.
+        """
+        self._validate_audio_file(audio_file)
+        job_id = self._create_job(audio_file, kwargs)
+        self._wait_for_job(job_id)
+        return self._get_transcript(job_id)
+
+    def _create_job(self, audio_file: str, options: dict) -> str:
+        config = {
+            "type": "transcription",
+            "transcription_config": {
+                "language": options.get("language") or "en",
+            },
+        }
+
+        if self.operating_point:
+            config["transcription_config"]["operating_point"] = self.operating_point
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                self.endpoint,
+                headers=self._headers(),
+                data={"config": json.dumps(config)},
+                files={"data_file": (os.path.basename(audio_file), f)},
+            )
+
+        if response.status_code != 201:
+            raise Exception(f"Speechmatics job creation failed: {response.text}")
+
+        data = response.json()
+        job_id = data.get("id") or data.get("job", {}).get("id")
+        if not job_id:
+            raise Exception("Speechmatics job creation response did not include a job id.")
+        return job_id
+
+    def _wait_for_job(self, job_id: str):
+        deadline = time.monotonic() + self.max_poll_seconds
+
+        while time.monotonic() < deadline:
+            response = requests.get(f"{self.endpoint}/{job_id}", headers=self._headers())
+            if response.status_code != 200:
+                raise Exception(f"Speechmatics status check failed: {response.text}")
+
+            status = self._extract_status(response.json())
+            if status in self.TERMINAL_STATUSES:
+                if status == "done":
+                    return
+                raise Exception(f"Speechmatics job ended with status: {status}")
+
+            time.sleep(self.poll_interval_seconds)
+
+        raise TimeoutError(f"Timed out waiting for Speechmatics job {job_id}")
+
+    def _get_transcript(self, job_id: str) -> str:
+        response = requests.get(
+            f"{self.endpoint}/{job_id}/transcript",
+            headers=self._headers(),
+            params={"format": "txt"},
+        )
+        if response.status_code != 200:
+            raise Exception(f"Speechmatics transcript retrieval failed: {response.text}")
+        return response.text
+
+    def _headers(self):
+        if not self.api_key:
+            raise ValueError("SPEECHMATICS_API_KEY is required for Speechmatics transcription.")
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    @staticmethod
+    def _extract_status(data: dict):
+        return data.get("status") or data.get("job", {}).get("status")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(
+                f"File size exceeds the maximum limit of {self.max_file_size_mb} MB."
+            )
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".m4a", ".mp4"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/tests/test_speechmatics.py
+++ b/tests/test_speechmatics.py
@@ -1,0 +1,73 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+from sapat.transcription.speechmatics import SpeechmaticsTranscription
+
+
+class SpeechmaticsTranscriptionTest(unittest.TestCase):
+    def setUp(self):
+        self.previous_key = os.environ.get("SPEECHMATICS_API_KEY")
+        os.environ["SPEECHMATICS_API_KEY"] = "test-key"
+
+    def tearDown(self):
+        if self.previous_key is None:
+            os.environ.pop("SPEECHMATICS_API_KEY", None)
+        else:
+            os.environ["SPEECHMATICS_API_KEY"] = self.previous_key
+
+    @patch("sapat.transcription.speechmatics.requests.get")
+    @patch("sapat.transcription.speechmatics.requests.post")
+    def test_transcribe_audio_creates_job_and_fetches_text_transcript(self, mock_post, mock_get):
+        create_response = MagicMock(status_code=201)
+        create_response.json.return_value = {"id": "job-123"}
+
+        status_response = MagicMock(status_code=200)
+        status_response.json.return_value = {"job": {"status": "done"}}
+
+        transcript_response = MagicMock(status_code=200, text="hello from speechmatics")
+
+        mock_post.return_value = create_response
+        mock_get.side_effect = [status_response, transcript_response]
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"audio")
+            audio.flush()
+
+            transcriber = SpeechmaticsTranscription(
+                temperature=0.3,
+                poll_interval_seconds=0,
+                max_poll_seconds=1,
+            )
+            result = transcriber.transcribe_audio(audio.name, language="en")
+
+        self.assertEqual(result, "hello from speechmatics")
+        posted_config = json.loads(mock_post.call_args.kwargs["data"]["config"])
+        self.assertEqual(posted_config["type"], "transcription")
+        self.assertEqual(posted_config["transcription_config"]["language"], "en")
+        self.assertEqual(
+            mock_get.call_args_list[1].kwargs["params"],
+            {"format": "txt"},
+        )
+
+    @patch("sapat.script.SpeechmaticsTranscription")
+    def test_cli_routes_speechmatics_api(self, mock_transcriber):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("sample.mp4").write_bytes(b"video")
+            result = runner.invoke(main, ["sample.mp4", "--api", "speechmatics"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_transcriber.assert_called_once_with(temperature=0.3)
+        mock_transcriber.return_value.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Speechmatics Batch transcription backend available through `--api speechmatics`
- wire the provider into the CLI and document the required Speechmatics environment variables
- add mocked unit tests for job creation, polling, transcript retrieval, and CLI routing

## Validation
- `/tmp/sapat-speechmatics-venv/bin/python -m unittest discover -s tests -v`
- `/tmp/sapat-speechmatics-venv/bin/python -m compileall src tests`
- `/tmp/sapat-speechmatics-venv/bin/python -m sapat.script --help`
- `git diff --check`

This is a companion implementation for daytonaio/content#13.