### PR TITLE
Add Hugging Face transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Hugging Face Inference APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Hugging Face Inference APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Hugging Face API token with access to an automatic speech recognition model
 
 ## Installation
 
@@ -53,6 +54,12 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Hugging Face
+   HUGGINGFACE_API_KEY=your_hugging_face_token_here
+   HUGGINGFACE_MODEL=openai/whisper-large-v3-turbo
+   # Optional: override when using a dedicated Inference Endpoint
+   HUGGINGFACE_API_ENDPOINT=
    ```
 
 ## Building and Installing the Package
@@ -115,11 +122,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api huggingface` for Hugging Face Inference API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Hugging Face example:
+
+```
+sapat my_video.mp4 --quality M --api huggingface
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +143,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Hugging Face). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.huggingface import HuggingFaceTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'huggingface'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'huggingface')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "huggingface":
+        transcriber = HuggingFaceTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/huggingface.py
+++ b/src/sapat/transcription/huggingface.py
@@ -1,0 +1,86 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+load_dotenv(".env")
+
+
+class HuggingFaceTranscription(TranscriptionBase):
+    """
+    Hugging Face Inference API implementation for automatic speech recognition.
+    """
+
+    def __init__(self, temperature: float):
+        self.api_key = os.getenv("HUGGINGFACE_API_KEY")
+        self.model = os.getenv("HUGGINGFACE_MODEL", "openai/whisper-large-v3-turbo")
+        self.endpoint = os.getenv("HUGGINGFACE_API_ENDPOINT")
+        self.temperature = temperature
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using the Hugging Face Inference API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_audio_file(audio_file)
+
+        if not self.api_key:
+            raise ValueError("HUGGINGFACE_API_KEY must be set.")
+
+        model = kwargs.get("model", self.model)
+        endpoint = self.endpoint or f"https://api-inference.huggingface.co/models/{model}"
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": self._content_type_for_audio(audio_file),
+            "X-Wait-For-Model": "true",
+        }
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(endpoint, headers=headers, data=f.read())
+
+        if response.status_code != 200:
+            raise Exception(f"Transcription failed: {response.text}")
+
+        try:
+            result = response.json()
+        except ValueError:
+            return response.text
+
+        if isinstance(result, dict) and "text" in result:
+            return result
+
+        if isinstance(result, list):
+            text = " ".join(item.get("text", "") for item in result if isinstance(item, dict))
+            if text:
+                return {"text": text}
+
+        return result
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [".mp3", ".wav", ".flac"]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}.")
+
+    def _content_type_for_audio(self, audio_file: str):
+        extension = os.path.splitext(audio_file)[1].lower()
+        return {
+            ".mp3": "audio/mpeg",
+            ".wav": "audio/wav",
+            ".flac": "audio/flac",
+        }[extension]

--- a/tests/test_huggingface_transcription.py
+++ b/tests/test_huggingface_transcription.py
@@ -1,0 +1,93 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.huggingface import HuggingFaceTranscription
+
+
+class HuggingFaceTranscriptionTest(unittest.TestCase):
+    def test_transcribe_audio_posts_mp3_bytes_to_model_endpoint(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"audio bytes")
+            audio.flush()
+
+            response = Mock()
+            response.status_code = 200
+            response.json.return_value = {"text": "hello from hugging face"}
+            response.text = '{"text":"hello from hugging face"}'
+
+            with patch.dict(
+                os.environ,
+                {
+                    "HUGGINGFACE_API_KEY": "hf_test",
+                    "HUGGINGFACE_MODEL": "openai/whisper-large-v3-turbo",
+                },
+            ), patch("sapat.transcription.huggingface.requests.post", return_value=response) as post:
+                transcriber = HuggingFaceTranscription(temperature=0.3)
+                result = transcriber.transcribe_audio(audio.name)
+
+        self.assertEqual(result, {"text": "hello from hugging face"})
+        post.assert_called_once()
+        url = post.call_args.args[0]
+        self.assertEqual(url, "https://api-inference.huggingface.co/models/openai/whisper-large-v3-turbo")
+        self.assertEqual(post.call_args.kwargs["data"], b"audio bytes")
+        self.assertEqual(post.call_args.kwargs["headers"]["Authorization"], "Bearer hf_test")
+        self.assertEqual(post.call_args.kwargs["headers"]["Content-Type"], "audio/mpeg")
+
+    def test_transcribe_audio_uses_endpoint_override(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"audio bytes")
+            audio.flush()
+
+            response = Mock()
+            response.status_code = 200
+            response.json.return_value = {"text": "endpoint output"}
+            response.text = '{"text":"endpoint output"}'
+
+            with patch.dict(
+                os.environ,
+                {
+                    "HUGGINGFACE_API_KEY": "hf_test",
+                    "HUGGINGFACE_API_ENDPOINT": "https://example.endpoints.huggingface.cloud",
+                },
+            ), patch("sapat.transcription.huggingface.requests.post", return_value=response) as post:
+                transcriber = HuggingFaceTranscription(temperature=0.3)
+                result = transcriber.transcribe_audio(audio.name)
+
+        self.assertEqual(result, {"text": "endpoint output"})
+        self.assertEqual(post.call_args.args[0], "https://example.endpoints.huggingface.cloud")
+
+    def test_transcribe_audio_sets_wav_content_type(self):
+        with tempfile.NamedTemporaryFile(suffix=".wav") as audio:
+            audio.write(b"audio bytes")
+            audio.flush()
+
+            response = Mock()
+            response.status_code = 200
+            response.json.return_value = {"text": "wav output"}
+            response.text = '{"text":"wav output"}'
+
+            with patch.dict(os.environ, {"HUGGINGFACE_API_KEY": "hf_test"}), patch(
+                "sapat.transcription.huggingface.requests.post", return_value=response
+            ) as post:
+                transcriber = HuggingFaceTranscription(temperature=0.3)
+                result = transcriber.transcribe_audio(audio.name)
+
+        self.assertEqual(result, {"text": "wav output"})
+        self.assertEqual(post.call_args.kwargs["headers"]["Content-Type"], "audio/wav")
+
+    def test_transcribe_audio_requires_api_key(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"audio bytes")
+            audio.flush()
+
+            with patch.dict(os.environ, {"HUGGINGFACE_API_KEY": ""}):
+                transcriber = HuggingFaceTranscription(temperature=0.3)
+
+                with self.assertRaisesRegex(ValueError, "HUGGINGFACE_API_KEY"):
+                    transcriber.transcribe_audio(audio.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Hugging Face Inference API transcription backend
- expose it through the existing --api option as --api huggingface
- document the required environment variables and add unit coverage for endpoint selection, auth, and content type handling

## Validation
- .venv/bin/python -m unittest discover -s tests
- .venv/bin/python -m sapat.script --help
- git diff --check

Note: the local macOS Python emitted an urllib3 LibreSSL warning during validation; tests and CLI help completed successfully.