### PR TITLE
Add DeepInfra transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ This tool automates the process of transcribing video files using multiple trans
    DEEPINFRA_TOKEN=your_deepinfra_token_here
    DEEPINFRA_MODEL=openai/whisper-large
    DEEPINFRA_API_ENDPOINT=https://api.deepinfra.com/v1/audio/transcriptions
+   DEEPINFRA_MODEL_NAME_CHAT=deepseek-ai/DeepSeek-V3
+   DEEPINFRA_OPENAI_BASE_URL=https://api.deepinfra.com/v1/openai
    ```
 
 ## Building and Installing the Package

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and DeepInfra APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and DeepInfra APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - DeepInfra API
 
 ## Installation
 
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # DeepInfra
+   DEEPINFRA_TOKEN=your_deepinfra_token_here
+   DEEPINFRA_MODEL=openai/whisper-large
+   DEEPINFRA_API_ENDPOINT=https://api.deepinfra.com/v1/audio/transcriptions
    ```
 
 ## Building and Installing the Package
@@ -115,11 +121,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api deepinfra` for DeepInfra API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+DeepInfra example:
+
+```
+sapat my_video.mp4 --quality H --language en --prompt "Product names: Sapat, Daytona" --api deepinfra
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +142,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and DeepInfra). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.deepinfra import DeepInfraTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'deepinfra'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'deepinfra')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "deepinfra":
+        transcriber = DeepInfraTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/deepinfra.py
+++ b/src/sapat/transcription/deepinfra.py
@@ -2,6 +2,7 @@ import os
 
 import requests
 from dotenv import load_dotenv
+from openai import OpenAI
 
 from .base import TranscriptionBase
 
@@ -17,9 +18,17 @@ class DeepInfraTranscription(TranscriptionBase):
     def __init__(self, temperature: float, response_format: str = "json"):
         self.api_key = os.getenv("DEEPINFRA_TOKEN")
         self.model = os.getenv("DEEPINFRA_MODEL", "openai/whisper-large")
+        self.model_name_chat = os.getenv(
+            "DEEPINFRA_MODEL_NAME_CHAT",
+            "deepseek-ai/DeepSeek-V3",
+        )
         self.endpoint = os.getenv(
             "DEEPINFRA_API_ENDPOINT",
             "https://api.deepinfra.com/v1/audio/transcriptions",
+        )
+        self.openai_base_url = os.getenv(
+            "DEEPINFRA_OPENAI_BASE_URL",
+            "https://api.deepinfra.com/v1/openai",
         )
         self.temperature = temperature
         self.response_format = response_format
@@ -53,6 +62,33 @@ class DeepInfraTranscription(TranscriptionBase):
                 return response.json()
             return response.text
         raise Exception(f"Transcription failed: {response.text}")
+
+    def generate_corrected_transcript(
+        self, audio_file: str, temperature: float, system_prompt: str
+    ):
+        client = OpenAI(api_key=self.api_key, base_url=self.openai_base_url)
+
+        transcription = self.transcribe_audio(audio_file)
+        transcription_text = (
+            transcription.get("text", "") if isinstance(transcription, dict)
+            else transcription
+        )
+
+        response = client.chat.completions.create(
+            model=self.model_name_chat,
+            temperature=temperature,
+            messages=[
+                {
+                    "role": "system",
+                    "content": system_prompt,
+                },
+                {
+                    "role": "user",
+                    "content": transcription_text,
+                },
+            ],
+        )
+        return response.choices[0].message.content
 
     def _validate_audio_file(self, audio_file: str):
         if not os.path.exists(audio_file):

--- a/src/sapat/transcription/deepinfra.py
+++ b/src/sapat/transcription/deepinfra.py
@@ -1,0 +1,72 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class DeepInfraTranscription(TranscriptionBase):
+    """
+    DeepInfra API implementation for OpenAI-compatible transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        self.api_key = os.getenv("DEEPINFRA_TOKEN")
+        self.model = os.getenv("DEEPINFRA_MODEL", "openai/whisper-large")
+        self.endpoint = os.getenv(
+            "DEEPINFRA_API_ENDPOINT",
+            "https://api.deepinfra.com/v1/audio/transcriptions",
+        )
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        self._validate_audio_file(audio_file)
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        data = {
+            "model": kwargs.get("model", self.model),
+            "response_format": kwargs.get("response_format", self.response_format),
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        if "language" in kwargs:
+            data["language"] = kwargs["language"]
+        if "prompt" in kwargs:
+            data["prompt"] = kwargs["prompt"]
+
+        with open(audio_file, "rb") as f:
+            files = {"file": f}
+            response = requests.post(
+                self.endpoint, headers=headers, data=data, files=files
+            )
+
+        if response.status_code == 200:
+            if data["response_format"] in ["json", "verbose_json"]:
+                return response.json()
+            return response.text
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(
+                f"File size exceeds the maximum limit of {self.max_file_size_mb} MB."
+            )
+
+        valid_extensions = [".mp3", ".wav", ".flac"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/tests/test_deepinfra.py
+++ b/tests/test_deepinfra.py
@@ -50,6 +50,67 @@ class DeepInfraTranscriptionTest(unittest.TestCase):
         finally:
             audio_path.unlink(missing_ok=True)
 
+    def test_generate_corrected_transcript_uses_deepinfra_chat_endpoint(self):
+        from sapat.transcription.deepinfra import DeepInfraTranscription
+
+        choice = Mock()
+        choice.message.content = "corrected transcript"
+        completion = Mock()
+        completion.choices = [choice]
+
+        chat_completions = Mock()
+        chat_completions.create.return_value = completion
+
+        chat = Mock()
+        chat.completions = chat_completions
+
+        client = Mock()
+        client.chat = chat
+
+        env = {
+            "DEEPINFRA_TOKEN": "test-token",
+            "DEEPINFRA_MODEL_NAME_CHAT": "meta-llama/test-chat-model",
+            "DEEPINFRA_OPENAI_BASE_URL": "https://api.deepinfra.com/v1/openai",
+        }
+
+        with patch.dict(os.environ, env, clear=False), patch(
+            "sapat.transcription.deepinfra.OpenAI", return_value=client
+        ) as openai, patch.object(
+            DeepInfraTranscription,
+            "transcribe_audio",
+            return_value={"text": "raw transcript"},
+        ):
+            transcriber = DeepInfraTranscription(temperature=0.2)
+            result = transcriber.generate_corrected_transcript(
+                "audio.mp3",
+                0.7,
+                "Correct spelling only.",
+            )
+
+        self.assertEqual(result, "corrected transcript")
+        openai.assert_called_once_with(
+            api_key="test-token",
+            base_url="https://api.deepinfra.com/v1/openai",
+        )
+        chat_completions.create.assert_called_once()
+
+        _, kwargs = chat_completions.create.call_args
+        self.assertEqual(kwargs["model"], "meta-llama/test-chat-model")
+        self.assertEqual(kwargs["temperature"], 0.7)
+        self.assertEqual(
+            kwargs["messages"],
+            [
+                {
+                    "role": "system",
+                    "content": "Correct spelling only.",
+                },
+                {
+                    "role": "user",
+                    "content": "raw transcript",
+                },
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deepinfra.py
+++ b/tests/test_deepinfra.py
@@ -1,0 +1,55 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+class DeepInfraTranscriptionTest(unittest.TestCase):
+    def test_transcribe_audio_posts_openai_compatible_payload(self):
+        from sapat.transcription.deepinfra import DeepInfraTranscription
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as audio:
+            audio.write(b"fake audio")
+            audio_path = Path(audio.name)
+
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"text": "transcribed with deepinfra"}
+
+        env = {
+            "DEEPINFRA_TOKEN": "test-token",
+            "DEEPINFRA_MODEL": "openai/whisper-large-v3",
+            "DEEPINFRA_API_ENDPOINT": "https://api.deepinfra.com/v1/audio/transcriptions",
+        }
+
+        try:
+            with patch.dict(os.environ, env, clear=False), patch(
+                "sapat.transcription.deepinfra.requests.post", return_value=response
+            ) as post:
+                result = DeepInfraTranscription(temperature=0.2).transcribe_audio(
+                    str(audio_path),
+                    language="en",
+                    prompt="product names: Sapat and Daytona",
+                    temperature=0.1,
+                )
+
+            self.assertEqual(result, {"text": "transcribed with deepinfra"})
+            post.assert_called_once()
+
+            _, kwargs = post.call_args
+            self.assertEqual(
+                kwargs["headers"], {"Authorization": "Bearer test-token"}
+            )
+            self.assertEqual(kwargs["data"]["model"], "openai/whisper-large-v3")
+            self.assertEqual(kwargs["data"]["response_format"], "json")
+            self.assertEqual(kwargs["data"]["language"], "en")
+            self.assertEqual(kwargs["data"]["prompt"], "product names: Sapat and Daytona")
+            self.assertEqual(kwargs["data"]["temperature"], 0.1)
+            self.assertIn("file", kwargs["files"])
+        finally:
+            audio_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a DeepInfra transcription provider using the OpenAI-compatible audio transcription endpoint
- wire `--api deepinfra` into the Sapat CLI
- support Sapat's existing `--correct` flow through DeepInfra's OpenAI-compatible chat endpoint
- document DeepInfra transcription and chat environment variables in the README
- add mocked unittest coverage for transcription payloads and corrected transcript chat calls

## Validation
- `PYTHONPATH=src py -3 -m unittest discover -s tests`
- `PYTHONPATH=src py -3 -m py_compile src/sapat/transcription/deepinfra.py src/sapat/script.py`
- `PYTHONPATH=src py -3 -m sapat.script --help`
- `git diff --check`