### PR TITLE
Add Soniox transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Soniox APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Soniox APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Soniox API
 
 ## Installation
 
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Soniox
+   SONIOX_API_KEY=your_soniox_api_key_here
+   SONIOX_MODEL=stt-async-v4
+   SONIOX_DESTROY_AFTER_TRANSCRIPTION=true
    ```
 
 ## Building and Installing the Package
@@ -115,6 +121,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api soniox` for Soniox Speech-to-Text API
 
 Example:
 
@@ -129,7 +136,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Soniox). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     "requests>=2.32.3",
     "python-dotenv>=1.0.1",
     "openai>=1.58.1",
-    "groq>=0.13.1"
+    "groq>=0.13.1",
+    "soniox>=1.0.0"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ requests
 click
 openai
 groq
+soniox
 build

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.soniox import SonioxTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'soniox'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'soniox')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "soniox":
+        transcriber = SonioxTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/soniox.py
+++ b/src/sapat/transcription/soniox.py
@@ -1,0 +1,66 @@
+import os
+
+from dotenv import load_dotenv
+from soniox import SonioxClient
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class SonioxTranscription(TranscriptionBase):
+    """
+    Soniox API implementation for asynchronous file transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        self.api_key = os.getenv("SONIOX_API_KEY")
+        self.model = os.getenv("SONIOX_MODEL", "stt-async-v4")
+        self.destroy_after_transcription = os.getenv(
+            "SONIOX_DESTROY_AFTER_TRANSCRIPTION", "true"
+        ).lower() not in {"0", "false", "no"}
+        self.temperature = temperature
+        self.response_format = response_format
+        self.client = SonioxClient()
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Soniox asynchronous Speech-to-Text.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional arguments for transcription.
+
+        Returns:
+        - dict: A dictionary containing the transcript text.
+        """
+        self._validate_audio_file(audio_file)
+
+        transcription = self.client.stt.transcribe(
+            model=kwargs.get("model", self.model),
+            file=audio_file,
+        )
+        self.client.stt.wait(transcription.id)
+        transcript = self.client.stt.get_transcript(transcription.id)
+
+        if self.destroy_after_transcription:
+            self.client.stt.destroy(transcription.id)
+
+        return {"text": transcript.text}
+
+    def generate_corrected_transcript(self, audio_file: str, temperature: float, system_prompt: str):
+        raise NotImplementedError(
+            "Transcript correction is not implemented for the Soniox provider yet."
+        )
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".m4a", ".mp4", ".webm"]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/tests/test_soniox_transcription.py
+++ b/tests/test_soniox_transcription.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from sapat.transcription.soniox import SonioxTranscription
+
+
+class FakeSttClient:
+    def __init__(self):
+        self.transcribe_calls = []
+        self.wait_calls = []
+        self.destroy_calls = []
+
+    def transcribe(self, **kwargs):
+        self.transcribe_calls.append(kwargs)
+        return SimpleNamespace(id="transcription-1")
+
+    def wait(self, transcription_id):
+        self.wait_calls.append(transcription_id)
+
+    def get_transcript(self, transcription_id):
+        return SimpleNamespace(text=f"transcript for {transcription_id}")
+
+    def destroy(self, transcription_id):
+        self.destroy_calls.append(transcription_id)
+
+
+class FakeSonioxClient:
+    def __init__(self):
+        self.stt = FakeSttClient()
+
+
+class SonioxTranscriptionTest(TestCase):
+    def test_transcribes_local_file_and_cleans_remote_job(self):
+        audio_file = Path("sample.mp3")
+        audio_file.write_bytes(b"fake audio")
+        try:
+            with patch("sapat.transcription.soniox.SonioxClient", FakeSonioxClient):
+                transcriber = SonioxTranscription(temperature=0.3)
+                result = transcriber.transcribe_audio(str(audio_file))
+
+            self.assertEqual(result, {"text": "transcript for transcription-1"})
+            self.assertEqual(
+                transcriber.client.stt.transcribe_calls,
+                [{"model": "stt-async-v4", "file": "sample.mp3"}],
+            )
+            self.assertEqual(transcriber.client.stt.wait_calls, ["transcription-1"])
+            self.assertEqual(transcriber.client.stt.destroy_calls, ["transcription-1"])
+        finally:
+            audio_file.unlink(missing_ok=True)
+
+    def test_rejects_unsupported_audio_extension(self):
+        with patch("sapat.transcription.soniox.SonioxClient", FakeSonioxClient):
+            transcriber = SonioxTranscription(temperature=0.3)
+
+        with self.assertRaises(ValueError):
+            transcriber._validate_audio_file("sample.txt")


### PR DESCRIPTION
## Summary

- Add a Soniox Speech-to-Text provider using the official Python SDK.
- Wire `--api soniox` into the CLI and document the required `SONIOX_API_KEY`/`SONIOX_MODEL` settings.
- Add mocked unit coverage for the async transcription flow and remote cleanup call.

## Verification

- `python3 -m venv .venv`
- `. .venv/bin/activate && python -m pip install -e .`
- `PYTHONPATH=src python -m unittest discover -s tests`
- `PYTHONPATH=src python -m py_compile src/sapat/script.py src/sapat/transcription/soniox.py tests/test_soniox_transcription.py`
- `PYTHONPATH=src python -m sapat.script --help`
- `git diff --check`
- `../../scripts/pre_push_privacy_check.sh .`

No API keys or account details are included.