### PR TITLE
Add Lemonfox transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Lemonfox APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Lemonfox APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Lemonfox Speech-to-Text API
 
 ## Installation
 
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Lemonfox
+   LEMONFOX_API_KEY=your_lemonfox_api_key_here
+   LEMONFOX_API_ENDPOINT=https://api.lemonfox.ai/v1/audio/transcriptions
+   LEMONFOX_RESPONSE_FORMAT=json
    ```
 
 ## Building and Installing the Package
@@ -115,11 +121,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api lemonfox` for Lemonfox Speech-to-Text API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Run with Lemonfox:
+
+```
+sapat my_video.mp4 --quality M --language english --prompt "Daytona, Sapat" --api lemonfox
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +142,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Lemonfox). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.lemonfox import LemonfoxTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'lemonfox'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'lemonfox')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "lemonfox":
+        transcriber = LemonfoxTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -1,9 +1,25 @@
 import click
 from pathlib import Path
-from .transcription.groq import GroqCloudTranscription
-from .transcription.azure import AzureTranscription
-from .transcription.openai import OpenAITranscription
-from .transcription.lemonfox import LemonfoxTranscription
+
+
+def create_transcriber(api: str, temperature: float):
+    if api.lower() == "groq":
+        from .transcription.groq import GroqCloudTranscription
+
+        return GroqCloudTranscription(temperature=temperature)
+    if api.lower() == "azure":
+        from .transcription.azure import AzureTranscription
+
+        return AzureTranscription(temperature=temperature)
+    if api.lower() == "openai":
+        from .transcription.openai import OpenAITranscription
+
+        return OpenAITranscription(temperature=temperature)
+    if api.lower() == "lemonfox":
+        from .transcription.lemonfox import LemonfoxTranscription
+
+        return LemonfoxTranscription(temperature=temperature)
+    raise ValueError(f"Unsupported API: {api}")
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -19,21 +35,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
 
     INPUT_PATH is the path to the video file or directory containing video files.
     """
-    # Initialize the correct transcription object
     input_path = Path(input_path)
-
-    # Handle file processing based on API choice
-    if api.lower() == "groq":
-        transcriber = GroqCloudTranscription(temperature=temperature)
-    elif api.lower() == "azure":
-        transcriber = AzureTranscription(temperature=temperature)
-    elif api.lower() == "openai":
-        transcriber = OpenAITranscription(temperature=temperature)
-    elif api.lower() == "lemonfox":
-        transcriber = LemonfoxTranscription(temperature=temperature)
-    else:
-        click.echo(f"Unsupported API: {api}")
-        return
+    transcriber = create_transcriber(api, temperature)
 
     if input_path.is_file():
         transcriber.process_file(input_path, language, prompt, temperature, quality, correct)

--- a/src/sapat/transcription/lemonfox.py
+++ b/src/sapat/transcription/lemonfox.py
@@ -1,0 +1,115 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+load_dotenv(".env")
+
+
+class LemonfoxTranscription(TranscriptionBase):
+    """
+    Lemonfox Speech-to-Text implementation.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the LemonfoxTranscription class.
+
+        Parameters:
+        - temperature (float): Accepted for CLI compatibility with other providers.
+        - response_format (str): Default response format for transcription.
+        """
+        self.api_key = os.getenv("LEMONFOX_API_KEY")
+        self.endpoint = os.getenv(
+            "LEMONFOX_API_ENDPOINT",
+            "https://api.lemonfox.ai/v1/audio/transcriptions",
+        )
+        self.response_format = os.getenv("LEMONFOX_RESPONSE_FORMAT", response_format)
+        self.temperature = temperature
+        self.max_file_size_mb = 100
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Lemonfox Speech-to-Text.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_audio_file(audio_file)
+
+        if not self.api_key:
+            raise ValueError("LEMONFOX_API_KEY is required for Lemonfox transcription.")
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        data = {
+            "response_format": kwargs.get("response_format", self.response_format),
+        }
+
+        if kwargs.get("language"):
+            data["language"] = kwargs["language"]
+        if kwargs.get("prompt"):
+            data["prompt"] = kwargs["prompt"]
+
+        with open(audio_file, "rb") as f:
+            files = {"file": f}
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                data=data,
+                files=files,
+            )
+
+        if response.status_code == 200:
+            if data["response_format"] in ["json", "verbose_json"]:
+                return response.json()
+            return response.text
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def generate_corrected_transcript(self, audio_file: str, temperature: float, system_prompt: str):
+        """
+        Lemonfox Speech-to-Text does not provide a transcript-correction chat API.
+        """
+        raise NotImplementedError("Correction is not implemented for Lemonfox.")
+
+    def _validate_audio_file(self, audio_file: str):
+        """
+        Validates the audio file for size and format.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+
+        Raises:
+        - Exception: If the file is invalid.
+        """
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [
+            ".mp3",
+            ".wav",
+            ".flac",
+            ".aac",
+            ".opus",
+            ".ogg",
+            ".m4a",
+            ".mp4",
+            ".mpeg",
+            ".mov",
+            ".webm",
+        ]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}."
+            )

--- a/tests/test_lemonfox_transcription.py
+++ b/tests/test_lemonfox_transcription.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.lemonfox import LemonfoxTranscription
+
+
+class LemonfoxTranscriptionTests(unittest.TestCase):
+    def test_transcribe_audio_posts_openai_compatible_form(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file:
+            audio_file.write(b"audio")
+            audio_file.flush()
+
+            response = Mock()
+            response.status_code = 200
+            response.json.return_value = {"text": "hello world"}
+
+            with patch.dict(os.environ, {"LEMONFOX_API_KEY": "test-key"}):
+                with patch("sapat.transcription.lemonfox.requests.post", return_value=response) as post:
+                    transcriber = LemonfoxTranscription(temperature=0.3)
+                    result = transcriber.transcribe_audio(
+                        audio_file.name,
+                        language="english",
+                        prompt="Daytona, Sapat",
+                    )
+
+            self.assertEqual(result, {"text": "hello world"})
+            post.assert_called_once()
+            _, kwargs = post.call_args
+            self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+            self.assertEqual(
+                kwargs["data"],
+                {
+                    "response_format": "json",
+                    "language": "english",
+                    "prompt": "Daytona, Sapat",
+                },
+            )
+            self.assertIn("file", kwargs["files"])
+
+    def test_transcribe_audio_requires_api_key(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file:
+            audio_file.write(b"audio")
+            audio_file.flush()
+
+            with patch.dict(os.environ, {"LEMONFOX_API_KEY": ""}):
+                transcriber = LemonfoxTranscription(temperature=0.3)
+                with self.assertRaisesRegex(ValueError, "LEMONFOX_API_KEY"):
+                    transcriber.transcribe_audio(audio_file.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+
+
+class ScriptTests(unittest.TestCase):
+    def test_cli_routes_lemonfox_provider(self):
+        runner = CliRunner()
+        transcriber = Mock()
+
+        with runner.isolated_filesystem():
+            with open("clip.mp4", "wb") as f:
+                f.write(b"video")
+
+            with patch("sapat.script.LemonfoxTranscription", return_value=transcriber) as constructor:
+                result = runner.invoke(main, ["clip.mp4", "--api", "lemonfox"])
+
+        self.assertEqual(result.exit_code, 0)
+        constructor.assert_called_once_with(temperature=0.3)
+        transcriber.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -15,11 +15,11 @@ class ScriptTests(unittest.TestCase):
             with open("clip.mp4", "wb") as f:
                 f.write(b"video")
 
-            with patch("sapat.script.LemonfoxTranscription", return_value=transcriber) as constructor:
+            with patch("sapat.script.create_transcriber", return_value=transcriber) as constructor:
                 result = runner.invoke(main, ["clip.mp4", "--api", "lemonfox"])
 
         self.assertEqual(result.exit_code, 0)
-        constructor.assert_called_once_with(temperature=0.3)
+        constructor.assert_called_once_with("lemonfox", 0.3)
         transcriber.process_file.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- add a Lemonfox Speech-to-Text provider available through `--api lemonfox`
- document the required Lemonfox environment variables and usage example
- add mocked unit coverage for the OpenAI-compatible transcription request and CLI routing

## Validation
- `. .venv/bin/activate && PYTHONPATH=src python -m unittest discover -s tests -v`
- `. .venv/bin/activate && PYTHONPATH=src python -m py_compile src/sapat/script.py src/sapat/transcription/lemonfox.py tests/test_lemonfox_transcription.py tests/test_script.py`
- `. .venv/bin/activate && PYTHONPATH=src python -m sapat.script --help`
- `git diff --check`

Related Daytona content bounty: daytonaio/content#13