### PR TITLE
feat: add Venice transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Venice APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Venice APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Venice API
 
 ## Installation
 
@@ -53,6 +54,12 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Venice
+   VENICE_API_KEY=your_venice_api_key_here
+   VENICE_MODEL=openai/whisper-large-v3
+   VENICE_API_ENDPOINT=https://api.venice.ai/api/v1/audio/transcriptions
+   VENICE_TIMESTAMPS=false
    ```
 
 ## Building and Installing the Package
@@ -115,11 +122,13 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api venice` for Venice API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+sapat my_video.mp4 --quality H --language en --api venice
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +138,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Venice). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.venice import VeniceTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'venice'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'venice')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "venice":
+        transcriber = VeniceTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/venice.py
+++ b/src/sapat/transcription/venice.py
@@ -1,0 +1,94 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+load_dotenv(".env")
+
+
+class VeniceTranscription(TranscriptionBase):
+    """
+    Venice API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the VeniceTranscription class.
+
+        Parameters:
+        - temperature (float): Kept for CLI parity with other providers.
+        - response_format (str): Default response format for transcription.
+        """
+        self.api_key = os.getenv("VENICE_API_KEY")
+        self.model = os.getenv("VENICE_MODEL", "openai/whisper-large-v3")
+        self.endpoint = os.getenv(
+            "VENICE_API_ENDPOINT",
+            "https://api.venice.ai/api/v1/audio/transcriptions",
+        )
+        self.timestamps = os.getenv("VENICE_TIMESTAMPS", "false").lower()
+        self.temperature = temperature
+        self.response_format = response_format
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Venice's transcription API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_audio_file(audio_file)
+        if not self.api_key:
+            raise ValueError("VENICE_API_KEY must be set to use the Venice API.")
+
+        response_format = kwargs.get("response_format", self.response_format)
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        data = {
+            "model": kwargs.get("model", self.model),
+            "response_format": response_format,
+            "timestamps": kwargs.get("timestamps", self.timestamps),
+        }
+
+        if kwargs.get("language"):
+            data["language"] = kwargs["language"]
+
+        with open(audio_file, "rb") as f:
+            files = {"file": f}
+            response = requests.post(self.endpoint, headers=headers, data=data, files=files)
+
+        if response.status_code == 200:
+            if response_format == "json":
+                return response.json()
+            return response.text
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def _validate_audio_file(self, audio_file: str):
+        """
+        Validates that the file exists and uses a Venice-supported audio format.
+        """
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        valid_extensions = [
+            ".wav",
+            ".wave",
+            ".flac",
+            ".m4a",
+            ".aac",
+            ".mp4",
+            ".mp3",
+            ".ogg",
+            ".oga",
+            ".webm",
+        ]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}."
+            )

--- a/tests/test_venice.py
+++ b/tests/test_venice.py
@@ -1,0 +1,56 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.venice import VeniceTranscription
+
+
+class VeniceTranscriptionTests(unittest.TestCase):
+    def test_transcribe_audio_posts_expected_multipart_payload(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"audio")
+            audio.flush()
+
+            fake_response = Mock()
+            fake_response.status_code = 200
+            fake_response.json.return_value = {"text": "hello"}
+
+            env = {
+                "VENICE_API_KEY": "test-key",
+                "VENICE_MODEL": "openai/whisper-large-v3",
+                "VENICE_API_ENDPOINT": "https://api.venice.ai/api/v1/audio/transcriptions",
+                "VENICE_TIMESTAMPS": "true",
+            }
+            with patch.dict(os.environ, env), patch(
+                "sapat.transcription.venice.requests.post", return_value=fake_response
+            ) as post:
+                transcriber = VeniceTranscription(temperature=0.3)
+                result = transcriber.transcribe_audio(audio.name, language="en")
+
+            self.assertEqual(result, {"text": "hello"})
+            args, kwargs = post.call_args
+            self.assertEqual(args[0], "https://api.venice.ai/api/v1/audio/transcriptions")
+            self.assertEqual(kwargs["headers"], {"Authorization": "Bearer test-key"})
+            self.assertEqual(
+                kwargs["data"],
+                {
+                    "model": "openai/whisper-large-v3",
+                    "response_format": "json",
+                    "timestamps": "true",
+                    "language": "en",
+                },
+            )
+            self.assertIn("file", kwargs["files"])
+
+    def test_transcribe_audio_requires_api_key(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio, patch.dict(
+            os.environ, {"VENICE_API_KEY": ""}, clear=True
+        ):
+            transcriber = VeniceTranscription(temperature=0.3)
+            with self.assertRaises(ValueError):
+                transcriber.transcribe_audio(audio.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Venice transcription provider using the multipart audio transcription endpoint
- wire `--api venice` into the CLI provider selection
- document the required Venice environment variables and usage example
- add focused unit coverage for the request payload and missing API key handling

## Verification
- `PYTHONPATH=src python3 -m unittest tests.test_venice -v`
- `python3 -m py_compile src/sapat/script.py src/sapat/transcription/venice.py tests/test_venice.py`
- `git diff --check`

No secrets are included. The provider reads credentials from `VENICE_API_KEY`.