### PR TITLE
feat: add Gladia transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This tool automates the process of transcribing video files using multiple trans
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Gladia APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Gladia API
 
 ## Installation
 
@@ -53,6 +54,13 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Gladia
+   GLADIA_API_KEY=your_gladia_api_key_here
+   GLADIA_UPLOAD_ENDPOINT=https://api.gladia.io/v2/upload
+   GLADIA_TRANSCRIPTION_ENDPOINT=https://api.gladia.io/v2/pre-recorded
+   GLADIA_POLL_INTERVAL_SECONDS=2
+   GLADIA_TIMEOUT_SECONDS=600
    ```
 
 ## Building and Installing the Package
@@ -115,11 +123,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api gladia` for Gladia API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Gladia example:
+
+```
+sapat my_video.mp4 --quality H --language en --api gladia
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +144,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Gladia). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.gladia import GladiaTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'gladia'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'gladia')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "gladia":
+        transcriber = GladiaTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/gladia.py
+++ b/src/sapat/transcription/gladia.py
@@ -1,0 +1,145 @@
+import os
+import time
+from typing import Optional
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class GladiaTranscription(TranscriptionBase):
+    """
+    Gladia API implementation for pre-recorded transcription.
+    """
+
+    def __init__(
+        self,
+        temperature: float,
+        response_format: str = "json",
+        poll_interval_seconds: Optional[float] = None,
+        timeout_seconds: Optional[float] = None,
+    ):
+        self.api_key = os.getenv("GLADIA_API_KEY")
+        self.upload_endpoint = os.getenv(
+            "GLADIA_UPLOAD_ENDPOINT", "https://api.gladia.io/v2/upload"
+        )
+        self.transcription_endpoint = os.getenv(
+            "GLADIA_TRANSCRIPTION_ENDPOINT",
+            "https://api.gladia.io/v2/pre-recorded",
+        )
+        self.temperature = temperature
+        self.response_format = response_format
+        self.poll_interval_seconds = (
+            poll_interval_seconds
+            if poll_interval_seconds is not None
+            else float(os.getenv("GLADIA_POLL_INTERVAL_SECONDS", "2"))
+        )
+        self.timeout_seconds = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else float(os.getenv("GLADIA_TIMEOUT_SECONDS", "600"))
+        )
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Gladia's v2 pre-recorded flow.
+        """
+        self._validate_audio_file(audio_file)
+        audio_url = self._upload_audio(audio_file)
+        result_url = self._create_transcription(audio_url, kwargs)
+        return self._poll_transcription(result_url)
+
+    def _headers(self):
+        if not self.api_key:
+            raise ValueError("GLADIA_API_KEY is required for Gladia transcription.")
+        return {"x-gladia-key": self.api_key}
+
+    def _upload_audio(self, audio_file: str):
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                self.upload_endpoint,
+                headers=self._headers(),
+                files={"audio": f},
+                timeout=60,
+            )
+        if response.status_code not in (200, 201):
+            raise Exception(f"Gladia upload failed: {response.text}")
+
+        audio_url = response.json().get("audio_url")
+        if not audio_url:
+            raise Exception("Gladia upload response did not include audio_url.")
+        return audio_url
+
+    def _create_transcription(self, audio_url: str, kwargs):
+        payload = {
+            "audio_url": audio_url,
+        }
+        language = kwargs.get("language")
+        if language:
+            payload["language_config"] = {
+                "languages": [language],
+                "code_switching": False,
+            }
+
+        response = requests.post(
+            self.transcription_endpoint,
+            headers={**self._headers(), "Content-Type": "application/json"},
+            json=payload,
+            timeout=60,
+        )
+        if response.status_code not in (200, 201):
+            raise Exception(f"Gladia transcription job failed: {response.text}")
+
+        job = response.json()
+        result_url = job.get("result_url")
+        if result_url:
+            return result_url
+
+        job_id = job.get("id")
+        if not job_id:
+            raise Exception("Gladia job response did not include result_url or id.")
+        return f"{self.transcription_endpoint}/{job_id}"
+
+    def _poll_transcription(self, result_url: str):
+        deadline = time.monotonic() + self.timeout_seconds
+        last_status = None
+
+        while time.monotonic() < deadline:
+            response = requests.get(result_url, headers=self._headers(), timeout=60)
+            if response.status_code != 200:
+                raise Exception(f"Gladia polling failed: {response.text}")
+
+            result = response.json()
+            last_status = result.get("status")
+            if last_status == "done":
+                return {
+                    "text": (
+                        result.get("result", {})
+                        .get("transcription", {})
+                        .get("full_transcript", "")
+                    )
+                }
+            if last_status in {"error", "failed"}:
+                raise Exception(f"Gladia transcription failed: {result}")
+
+            time.sleep(self.poll_interval_seconds)
+
+        raise TimeoutError(
+            f"Gladia transcription timed out after {self.timeout_seconds} seconds "
+            f"(last status: {last_status})."
+        )
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".m4a", ".mp4"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/tests/test_gladia.py
+++ b/tests/test_gladia.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+sys.modules.setdefault("groq", types.SimpleNamespace(Groq=object))
+sys.modules.setdefault(
+    "openai", types.SimpleNamespace(OpenAI=object, AzureOpenAI=object)
+)
+
+from sapat.script import main
+from sapat.transcription.gladia import GladiaTranscription
+
+
+class GladiaTranscriptionTests(unittest.TestCase):
+    def test_transcribe_audio_uploads_creates_job_and_polls_result(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"fake audio")
+            audio.flush()
+
+            responses = [
+                Mock(
+                    status_code=201,
+                    json=Mock(return_value={"audio_url": "https://api.gladia.io/file/1"}),
+                    text="",
+                ),
+                Mock(
+                    status_code=201,
+                    json=Mock(
+                        return_value={
+                            "id": "job-1",
+                            "result_url": "https://api.gladia.io/v2/pre-recorded/job-1",
+                        }
+                    ),
+                    text="",
+                ),
+            ]
+            poll_response = Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "status": "done",
+                        "result": {
+                            "transcription": {
+                                "full_transcript": "Transcript from Gladia."
+                            }
+                        },
+                    }
+                ),
+                text="",
+            )
+
+            with patch.dict(os.environ, {"GLADIA_API_KEY": "test-key"}), patch(
+                "sapat.transcription.gladia.requests.post", side_effect=responses
+            ) as post, patch(
+                "sapat.transcription.gladia.requests.get", return_value=poll_response
+            ) as get:
+                transcriber = GladiaTranscription(
+                    temperature=0.3, poll_interval_seconds=0, timeout_seconds=1
+                )
+
+                result = transcriber.transcribe_audio(audio.name, language="en")
+
+        self.assertEqual(result, {"text": "Transcript from Gladia."})
+        self.assertEqual(post.call_count, 2)
+        self.assertEqual(get.call_count, 1)
+        self.assertEqual(post.call_args_list[1].kwargs["json"]["language_config"], {
+            "languages": ["en"],
+            "code_switching": False,
+        })
+
+    def test_cli_routes_gladia_api_choice(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video:
+            with patch("sapat.script.GladiaTranscription") as transcriber_cls:
+                transcriber = transcriber_cls.return_value
+                runner = CliRunner()
+                result = runner.invoke(main, [video.name, "--api", "gladia"])
+
+        self.assertEqual(result.exit_code, 0)
+        transcriber_cls.assert_called_once_with(temperature=0.3)
+        transcriber.process_file.assert_called_once()
+        self.assertEqual(Path(transcriber.process_file.call_args.args[0]), Path(video.name))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Gladia pre-recorded transcription provider using the v2 upload, job creation, and polling flow
- expose `--api gladia` in the CLI and document Gladia environment variables
- add mocked tests for upload/job/poll result parsing and CLI routing

## Verification
- `PYTHONPATH=src python3 -m unittest discover -s tests -v`
- `python3 -m compileall src tests`
- `git diff --check`

Companion implementation for Daytona content bounty daytonaio/content#13.