### PR TITLE
Add IBM Watson Speech to Text provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, IBM Watson Speech to Text, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, IBM Watson Speech to Text, and OpenAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -17,6 +17,7 @@ This tool automates the process of transcribing video files using multiple trans
 - API access for one or more supported services:
   - Azure OpenAI API
   - Groq Cloud API
+  - IBM Watson Speech to Text API
   - OpenAI API
 
 ## Installation
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # IBM Watson Speech to Text
+   IBM_WATSON_STT_API_KEY=your_ibm_watson_api_key_here
+   IBM_WATSON_STT_URL=https://api.us-south.speech-to-text.watson.cloud.ibm.com/instances/your_instance_id
+   IBM_WATSON_STT_MODEL=en-US_BroadbandModel
    ```
 
 ## Building and Installing the Package
@@ -114,6 +120,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
 - `--api`: Specify the API to use for transcription.
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
+   - `--api ibm` for IBM Watson Speech to Text API
    - `--api openai` for OpenAI API
 
 Example:
@@ -129,7 +136,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, IBM Watson Speech to Text, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.watson import IBMWatsonTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'ibm'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'ibm')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "ibm":
+        transcriber = IBMWatsonTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/watson.py
+++ b/src/sapat/transcription/watson.py
@@ -1,0 +1,84 @@
+import mimetypes
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class IBMWatsonTranscription(TranscriptionBase):
+    """
+    IBM Watson Speech to Text implementation.
+    """
+
+    def __init__(self, temperature: float):
+        self.api_key = os.getenv("IBM_WATSON_STT_API_KEY")
+        self.endpoint = os.getenv("IBM_WATSON_STT_URL")
+        self.model = os.getenv("IBM_WATSON_STT_MODEL")
+        self.temperature = temperature
+        self.max_file_size_mb = 100
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using IBM Watson Speech to Text.
+        """
+        self._validate_config()
+        self._validate_audio_file(audio_file)
+
+        params = {}
+        if self.model:
+            params["model"] = self.model
+
+        content_type = mimetypes.guess_type(audio_file)[0] or "audio/mpeg"
+        recognize_url = self._recognize_url()
+
+        with open(audio_file, "rb") as audio:
+            response = requests.post(
+                recognize_url,
+                auth=("apikey", self.api_key),
+                headers={"Content-Type": content_type},
+                params=params,
+                data=audio,
+            )
+
+        if response.status_code != 200:
+            raise Exception(f"Transcription failed: {response.text}")
+
+        return self._extract_transcript(response.json())
+
+    def _recognize_url(self):
+        endpoint = self.endpoint.rstrip("/")
+        if endpoint.endswith("/v1/recognize"):
+            return endpoint
+        return endpoint + "/v1/recognize"
+
+    def _validate_config(self):
+        if not self.api_key:
+            raise ValueError("IBM_WATSON_STT_API_KEY is required for IBM Watson transcription.")
+        if not self.endpoint:
+            raise ValueError("IBM_WATSON_STT_URL is required for IBM Watson transcription.")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".ogg", ".webm"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}.")
+
+    @staticmethod
+    def _extract_transcript(payload):
+        transcripts = []
+        for result in payload.get("results", []):
+            alternatives = result.get("alternatives") or []
+            if alternatives:
+                transcripts.append(alternatives[0].get("transcript", "").strip())
+        return " ".join(part for part in transcripts if part)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,23 @@
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+
+
+class ScriptTest(unittest.TestCase):
+    @patch("sapat.script.IBMWatsonTranscription")
+    def test_ibm_api_routes_to_watson_transcriber(self, watson):
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video:
+            result = runner.invoke(main, [video.name, "--api", "ibm"])
+
+        self.assertEqual(result.exit_code, 0)
+        watson.assert_called_once_with(temperature=0.3)
+        watson.return_value.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_watson_transcription.py
+++ b/tests/test_watson_transcription.py
@@ -1,0 +1,68 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.watson import IBMWatsonTranscription
+
+
+class IBMWatsonTranscriptionTest(unittest.TestCase):
+    def setUp(self):
+        self.original_env = os.environ.copy()
+        os.environ["IBM_WATSON_STT_API_KEY"] = "test-key"
+        os.environ["IBM_WATSON_STT_URL"] = "https://api.us-south.speech-to-text.watson.cloud.ibm.com/instances/test"
+        os.environ["IBM_WATSON_STT_MODEL"] = "en-US_BroadbandModel"
+        self.audio_file = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        self.audio_file.write(b"audio")
+        self.audio_file.close()
+
+    def tearDown(self):
+        os.unlink(self.audio_file.name)
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    @patch("sapat.transcription.watson.requests.post")
+    def test_transcribe_audio_posts_to_recognize_endpoint(self, post):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "results": [
+                {"alternatives": [{"transcript": "hello world "}]},
+                {"alternatives": [{"transcript": "from watson"}]},
+            ]
+        }
+        post.return_value = response
+
+        result = IBMWatsonTranscription(temperature=0.3).transcribe_audio(self.audio_file.name)
+
+        self.assertEqual(result, "hello world from watson")
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        self.assertEqual(
+            post.call_args[0][0],
+            "https://api.us-south.speech-to-text.watson.cloud.ibm.com/instances/test/v1/recognize",
+        )
+        self.assertEqual(kwargs["auth"], ("apikey", "test-key"))
+        self.assertEqual(kwargs["headers"], {"Content-Type": "audio/mpeg"})
+        self.assertEqual(kwargs["params"], {"model": "en-US_BroadbandModel"})
+
+    def test_missing_api_key_raises_clear_error(self):
+        del os.environ["IBM_WATSON_STT_API_KEY"]
+        transcriber = IBMWatsonTranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "IBM_WATSON_STT_API_KEY"):
+            transcriber.transcribe_audio(self.audio_file.name)
+
+    def test_recognize_url_accepts_full_endpoint(self):
+        os.environ["IBM_WATSON_STT_URL"] = (
+            "https://api.us-south.speech-to-text.watson.cloud.ibm.com/instances/test/v1/recognize"
+        )
+
+        self.assertEqual(
+            IBMWatsonTranscription(temperature=0.3)._recognize_url(),
+            "https://api.us-south.speech-to-text.watson.cloud.ibm.com/instances/test/v1/recognize",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an IBM Watson Speech to Text provider using the synchronous `/v1/recognize` HTTP API
- expose it through `sapat --api ibm`
- document the required IBM Watson environment variables in the README
- add focused mocked unit coverage for endpoint construction, transcript extraction, missing config, and CLI routing

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m py_compile src/sapat/script.py src/sapat/transcription/watson.py tests/test_watson_transcription.py tests/test_script.py`
- `.venv/bin/python -m sapat.script --help`
- `git diff --check`

Companion implementation for Daytona content bounty daytonaio/content#13.

No API keys, recordings, payment details, private account data, or local sensitive paths are included.