### PR TITLE
Add Together AI transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Together AI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Together AI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Together AI API
 
 ## Installation
 
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Together AI
+   TOGETHER_API_KEY=your_together_api_key_here
+   TOGETHER_MODEL=openai/whisper-large-v3
+   TOGETHER_API_ENDPOINT=https://api.together.xyz/v1/audio/transcriptions
    ```
 
 ## Building and Installing the Package
@@ -115,6 +121,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api together` for Together AI API
 
 Example:
 
@@ -129,7 +136,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Together AI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.together import TogetherAITranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'together'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'together')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "together":
+        transcriber = TogetherAITranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/together.py
+++ b/src/sapat/transcription/together.py
@@ -1,0 +1,85 @@
+import mimetypes
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class TogetherAITranscription(TranscriptionBase):
+    """
+    Together AI API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        self.api_key = os.getenv("TOGETHER_API_KEY")
+        self.model = os.getenv("TOGETHER_MODEL", "openai/whisper-large-v3")
+        self.endpoint = os.getenv(
+            "TOGETHER_API_ENDPOINT",
+            "https://api.together.xyz/v1/audio/transcriptions",
+        )
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = 100
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Together AI speech-to-text.
+        """
+        self._validate_config()
+        self._validate_audio_file(audio_file)
+
+        data = {
+            "model": kwargs.get("model", self.model),
+            "response_format": kwargs.get("response_format", self.response_format),
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        if kwargs.get("language"):
+            data["language"] = kwargs["language"]
+        if kwargs.get("prompt"):
+            data["prompt"] = kwargs["prompt"]
+
+        content_type = mimetypes.guess_type(audio_file)[0] or "audio/mpeg"
+
+        with open(audio_file, "rb") as audio:
+            files = {
+                "file": (os.path.basename(audio_file), audio, content_type),
+            }
+            response = requests.post(
+                self.endpoint,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                data=data,
+                files=files,
+            )
+
+        if response.status_code != 200:
+            raise Exception(f"Transcription failed: {response.text}")
+
+        return self._extract_transcript(response.json())
+
+    def _validate_config(self):
+        if not self.api_key:
+            raise ValueError("TOGETHER_API_KEY is required for Together AI transcription.")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [".mp3", ".wav", ".m4a", ".webm", ".flac", ".ogg", ".opus", ".aac"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}.")
+
+    @staticmethod
+    def _extract_transcript(payload):
+        if isinstance(payload, dict):
+            return payload.get("text", "")
+        return ""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,23 @@
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+
+
+class ScriptTest(unittest.TestCase):
+    @patch("sapat.script.TogetherAITranscription")
+    def test_together_api_routes_to_together_transcriber(self, together):
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video:
+            result = runner.invoke(main, [video.name, "--api", "together"])
+
+        self.assertEqual(result.exit_code, 0)
+        together.assert_called_once_with(temperature=0.3)
+        together.return_value.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_together_transcription.py
+++ b/tests/test_together_transcription.py
@@ -1,0 +1,59 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.together import TogetherAITranscription
+
+
+class TogetherAITranscriptionTest(unittest.TestCase):
+    def setUp(self):
+        self.original_env = os.environ.copy()
+        os.environ["TOGETHER_API_KEY"] = "test-key"
+        os.environ["TOGETHER_MODEL"] = "openai/whisper-large-v3"
+        os.environ["TOGETHER_API_ENDPOINT"] = "https://api.together.xyz/v1/audio/transcriptions"
+        self.audio_file = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        self.audio_file.write(b"audio")
+        self.audio_file.close()
+
+    def tearDown(self):
+        os.unlink(self.audio_file.name)
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    @patch("sapat.transcription.together.requests.post")
+    def test_transcribe_audio_posts_multipart_request(self, post):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"text": "hello from together"}
+        post.return_value = response
+
+        result = TogetherAITranscription(temperature=0.2).transcribe_audio(
+            self.audio_file.name,
+            language="en",
+            prompt="product names",
+        )
+
+        self.assertEqual(result, "hello from together")
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        self.assertEqual(post.call_args[0][0], "https://api.together.xyz/v1/audio/transcriptions")
+        self.assertEqual(kwargs["headers"], {"Authorization": "Bearer test-key"})
+        self.assertEqual(kwargs["data"]["model"], "openai/whisper-large-v3")
+        self.assertEqual(kwargs["data"]["response_format"], "json")
+        self.assertEqual(kwargs["data"]["temperature"], 0.2)
+        self.assertEqual(kwargs["data"]["language"], "en")
+        self.assertEqual(kwargs["data"]["prompt"], "product names")
+        self.assertEqual(kwargs["files"]["file"][0], os.path.basename(self.audio_file.name))
+        self.assertEqual(kwargs["files"]["file"][2], "audio/mpeg")
+
+    def test_missing_api_key_raises_clear_error(self):
+        del os.environ["TOGETHER_API_KEY"]
+        transcriber = TogetherAITranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "TOGETHER_API_KEY"):
+            transcriber.transcribe_audio(self.audio_file.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Together AI transcription provider using the multipart audio transcription endpoint
- expose it through `sapat --api together`
- document the required Together AI environment variables in the README
- add focused mocked unit coverage for request construction, transcript extraction, missing config, and CLI routing

## Validation
- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v`
- `PYTHONPATH=src .venv/bin/python -m py_compile src/sapat/script.py src/sapat/transcription/together.py tests/test_together_transcription.py tests/test_script.py`
- `PYTHONPATH=src .venv/bin/python -m sapat.script --help`
- `git diff --check`

Companion implementation for Daytona content bounty daytonaio/content#13.

No API keys, recordings, payment details, private account data, or local sensitive paths are included.