### PR TITLE
Add fal.ai transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This tool automates the process of transcribing video files using multiple trans
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and fal.ai APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - fal.ai API
 
 ## Installation
 
@@ -53,6 +54,13 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # fal.ai
+   FAL_KEY=your_fal_key_here
+   FAL_MODEL_ID=fal-ai/whisper
+   FAL_TASK=transcribe
+   FAL_CHUNK_LEVEL=segment
+   FAL_BATCH_SIZE=64
    ```
 
 ## Building and Installing the Package
@@ -115,6 +123,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api fal` for fal.ai Whisper API
 
 Example:
 
@@ -129,7 +138,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and fal.ai). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     "requests>=2.32.3",
     "python-dotenv>=1.0.1",
     "openai>=1.58.1",
-    "groq>=0.13.1"
+    "groq>=0.13.1",
+    "fal-client>=0.7.0"
 ]
 
 [project.scripts]

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.fal import FalTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'fal'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'fal')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "fal":
+        transcriber = FalTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/fal.py
+++ b/src/sapat/transcription/fal.py
@@ -1,0 +1,85 @@
+import os
+
+import fal_client
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+# Load environment variables
+load_dotenv(".env")
+
+
+class FalTranscription(TranscriptionBase):
+    """
+    fal.ai Whisper API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float):
+        """
+        Initializes the FalTranscription class.
+
+        Parameters:
+        - temperature (float): Accepted for CLI compatibility.
+        """
+        self.api_key = os.getenv("FAL_KEY")
+        self.model_id = os.getenv("FAL_MODEL_ID", "fal-ai/whisper")
+        self.task = os.getenv("FAL_TASK", "transcribe")
+        self.chunk_level = os.getenv("FAL_CHUNK_LEVEL", "segment")
+        self.batch_size = int(os.getenv("FAL_BATCH_SIZE", "64"))
+        self.temperature = temperature
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using fal.ai's Whisper API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict: The fal.ai transcription response.
+        """
+        self._validate_audio_file(audio_file)
+
+        audio_url = fal_client.upload_file(audio_file)
+        arguments = {
+            "audio_url": audio_url,
+            "task": kwargs.get("task", self.task),
+            "chunk_level": kwargs.get("chunk_level", self.chunk_level),
+            "batch_size": kwargs.get("batch_size", self.batch_size),
+        }
+
+        language = kwargs.get("language")
+        if language:
+            arguments["language"] = language
+
+        prompt = kwargs.get("prompt")
+        if prompt:
+            arguments["prompt"] = prompt
+
+        return fal_client.subscribe(self.model_id, arguments=arguments)
+
+    def generate_corrected_transcript(self, audio_file: str, temperature: float, system_prompt: str):
+        """
+        Transcript correction is not implemented for fal.ai.
+        """
+        raise NotImplementedError("Correction is not implemented for the fal.ai transcription API.")
+
+    def _validate_audio_file(self, audio_file: str):
+        """
+        Validates the audio file for size, format, and configuration.
+        """
+        if not self.api_key:
+            raise ValueError("FAL_KEY is required for fal.ai transcription.")
+
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}.")

--- a/tests/test_fal_transcription.py
+++ b/tests/test_fal_transcription.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sapat.transcription.fal import FalTranscription
+
+
+class FalTranscriptionTests(unittest.TestCase):
+    def test_transcribe_audio_uploads_file_and_subscribes_to_whisper(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file:
+            audio_file.write(b"audio")
+            audio_file.flush()
+
+            with patch.dict(os.environ, {"FAL_KEY": "test-key"}):
+                with patch("sapat.transcription.fal.fal_client.upload_file", return_value="https://fal.media/test.mp3") as upload:
+                    with patch("sapat.transcription.fal.fal_client.subscribe", return_value={"text": "hello world"}) as subscribe:
+                        transcriber = FalTranscription(temperature=0.3)
+                        result = transcriber.transcribe_audio(
+                            audio_file.name,
+                            language="en",
+                            prompt="Daytona, Sapat",
+                        )
+
+        self.assertEqual(result, {"text": "hello world"})
+        upload.assert_called_once_with(audio_file.name)
+        subscribe.assert_called_once_with(
+            "fal-ai/whisper",
+            arguments={
+                "audio_url": "https://fal.media/test.mp3",
+                "task": "transcribe",
+                "chunk_level": "segment",
+                "batch_size": 64,
+                "language": "en",
+                "prompt": "Daytona, Sapat",
+            },
+        )
+
+    def test_transcribe_audio_requires_api_key(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file:
+            audio_file.write(b"audio")
+            audio_file.flush()
+
+            with patch.dict(os.environ, {"FAL_KEY": ""}):
+                transcriber = FalTranscription(temperature=0.3)
+                with self.assertRaisesRegex(ValueError, "FAL_KEY"):
+                    transcriber.transcribe_audio(audio_file.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+
+
+class ScriptTests(unittest.TestCase):
+    def test_cli_routes_fal_provider(self):
+        runner = CliRunner()
+        transcriber = Mock()
+
+        with runner.isolated_filesystem():
+            with open("clip.mp4", "wb") as f:
+                f.write(b"video")
+
+            with patch("sapat.script.FalTranscription", return_value=transcriber) as constructor:
+                result = runner.invoke(main, ["clip.mp4", "--api", "fal"])
+
+        self.assertEqual(result.exit_code, 0)
+        constructor.assert_called_once_with(temperature=0.3)
+        transcriber.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adds a `fal` transcription provider backed by `fal-client` and the `fal-ai/whisper` model
- wires `--api fal` into the Sapat CLI
- documents `FAL_KEY`, `FAL_MODEL_ID`, `FAL_TASK`, `FAL_CHUNK_LEVEL`, and `FAL_BATCH_SIZE`
- adds unittest coverage for provider routing and fal.ai payload construction

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m py_compile src/sapat/script.py src/sapat/transcription/fal.py tests/test_fal_transcription.py tests/test_script.py`
- `.venv/bin/python -m sapat.script --help`
- `git diff --check`

Note: local tests emitted a Python/urllib3 LibreSSL warning from the macOS Python runtime, but all tests passed. I did not run a live fal.ai transcription because no API key or sample recording is committed.

Transparency: AI-assisted with Codex and checked against the Sapat source plus fal.ai public docs.