### PR TITLE
feat: add Replicate transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Replicate APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Replicate APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Replicate API
 
 ## Installation
 
@@ -53,6 +54,12 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Replicate
+   REPLICATE_API_TOKEN=your_replicate_api_token_here
+   REPLICATE_MODEL=openai/whisper
+   REPLICATE_TRANSLATE=false
+   REPLICATE_MAX_FILE_SIZE_MB=100
    ```
 
 ## Building and Installing the Package
@@ -115,11 +122,15 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api replicate` for Replicate-hosted Whisper
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+
+# Run the same file through Replicate-hosted Whisper
+sapat my_video.mp4 --quality M --api replicate
 ```
 
 - If a file is provided, it will process that single file.
@@ -127,9 +138,17 @@ sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --
 
 The script will create a `.txt` file with the same name as the input video file, containing the transcription.
 
+### Replicate notes
+
+The Replicate provider uses the official Python client so local audio files can be uploaded directly to Replicate. The default `REPLICATE_MODEL` is `openai/whisper`, but you can point it at another Replicate model reference that accepts an `audio` input and returns text, `transcription`, or segment output.
+
+Set `REPLICATE_TRANSLATE=true` when you want Whisper to translate speech into English instead of preserving the source language. The `--language`, `--prompt`, and `--temperature` flags remain accepted for CLI compatibility, but Replicate model support for those fields depends on the selected model.
+
+Transcript correction with `--correct` is not supported by the Replicate provider yet. Run the transcription without `--correct`, then post-process the generated text separately if needed.
+
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Replicate). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     "requests>=2.32.3",
     "python-dotenv>=1.0.1",
     "openai>=1.58.1",
-    "groq>=0.13.1"
+    "groq>=0.13.1",
+    "replicate>=1.0.0"
 ]
 
 [project.scripts]

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.replicate import ReplicateTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'replicate'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'replicate')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -21,6 +22,12 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
     # Initialize the correct transcription object
     input_path = Path(input_path)
 
+    if correct and api.lower() == "replicate":
+        raise click.ClickException(
+            "Transcript correction is not supported for the Replicate API yet. "
+            "Run without --correct, then post-process the transcript separately."
+        )
+
     # Handle file processing based on API choice
     if api.lower() == "groq":
         transcriber = GroqCloudTranscription(temperature=temperature)
@@ -28,6 +35,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "replicate":
+        transcriber = ReplicateTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/replicate.py
+++ b/src/sapat/transcription/replicate.py
@@ -1,0 +1,106 @@
+import os
+from dotenv import load_dotenv
+import replicate
+from .base import TranscriptionBase
+
+# Load environment variables
+load_dotenv(".env")
+
+
+class ReplicateTranscription(TranscriptionBase):
+    """
+    Replicate API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float):
+        """
+        Initializes the ReplicateTranscription class.
+
+        Parameters:
+        - temperature (float): Accepted for CLI compatibility. Replicate's
+          default Whisper model does not expose temperature.
+        """
+        self.api_token = os.getenv("REPLICATE_API_TOKEN")
+        self.model_ref = os.getenv("REPLICATE_MODEL", "openai/whisper")
+        self.translate = os.getenv("REPLICATE_TRANSLATE", "false").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        self.max_file_size_mb = int(os.getenv("REPLICATE_MAX_FILE_SIZE_MB", "100"))
+        self.temperature = temperature
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using a Replicate-hosted speech-to-text model.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict: A Sapat-compatible transcription result with a `text` key.
+        """
+        self._validate_audio_file(audio_file)
+        if not self.api_token:
+            raise ValueError("REPLICATE_API_TOKEN must be set to use the Replicate API.")
+
+        os.environ["REPLICATE_API_TOKEN"] = self.api_token
+
+        with open(audio_file, "rb") as audio:
+            output = replicate.run(
+                self.model_ref,
+                input=self._build_input(audio, kwargs),
+            )
+
+        return {"text": self._extract_transcription_text(output)}
+
+    def _build_input(self, audio, kwargs):
+        payload = {"audio": audio}
+        whisper_model = os.getenv("REPLICATE_WHISPER_MODEL")
+        if whisper_model:
+            payload["model"] = whisper_model
+
+        translate = kwargs.get("translate", self.translate)
+        if translate:
+            payload["translate"] = bool(translate)
+
+        return payload
+
+    def _extract_transcription_text(self, output):
+        if isinstance(output, str):
+            return output
+
+        if isinstance(output, dict):
+            for key in ("transcription", "text", "output"):
+                value = output.get(key)
+                if isinstance(value, str):
+                    return value
+            if isinstance(output.get("segments"), list):
+                return " ".join(
+                    segment.get("text", "").strip()
+                    for segment in output["segments"]
+                    if isinstance(segment, dict) and segment.get("text")
+                ).strip()
+
+        if isinstance(output, list):
+            return "".join(str(part) for part in output)
+
+        raise ValueError(f"Unsupported Replicate transcription output: {output!r}")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise ValueError(
+                f"File size exceeds the Replicate upload limit of {self.max_file_size_mb} MB."
+            )
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".m4a", ".ogg"]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}."
+            )

--- a/src/sapat/transcription/replicate.py
+++ b/src/sapat/transcription/replicate.py
@@ -46,10 +46,10 @@ class ReplicateTranscription(TranscriptionBase):
         if not self.api_token:
             raise ValueError("REPLICATE_API_TOKEN must be set to use the Replicate API.")
 
-        os.environ["REPLICATE_API_TOKEN"] = self.api_token
+        client = replicate.Client(api_token=self.api_token)
 
         with open(audio_file, "rb") as audio:
-            output = replicate.run(
+            output = client.run(
                 self.model_ref,
                 input=self._build_input(audio, kwargs),
             )
@@ -78,11 +78,13 @@ class ReplicateTranscription(TranscriptionBase):
                 if isinstance(value, str):
                     return value
             if isinstance(output.get("segments"), list):
-                return " ".join(
+                text = " ".join(
                     segment.get("text", "").strip()
                     for segment in output["segments"]
                     if isinstance(segment, dict) and segment.get("text")
                 ).strip()
+                if text:
+                    return text
 
         if isinstance(output, list):
             return "".join(str(part) for part in output)

--- a/tests/test_replicate_transcription.py
+++ b/tests/test_replicate_transcription.py
@@ -1,0 +1,74 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from sapat.transcription.replicate import ReplicateTranscription
+
+
+class ReplicateTranscriptionTests(unittest.TestCase):
+    def setUp(self):
+        self.env_patch = patch.dict(
+            os.environ,
+            {
+                "REPLICATE_API_TOKEN": "test-token",
+                "REPLICATE_MODEL": "openai/whisper",
+            },
+            clear=False,
+        )
+        self.env_patch.start()
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.audio_path = Path(self.tmpdir.name) / "sample.mp3"
+        self.audio_path.write_bytes(b"fake audio")
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        self.env_patch.stop()
+
+    @patch("sapat.transcription.replicate.replicate.run")
+    def test_transcribe_audio_returns_text_from_replicate_transcription(self, run):
+        run.return_value = {"transcription": "hello from replicate"}
+
+        result = ReplicateTranscription(temperature=0.3).transcribe_audio(str(self.audio_path))
+
+        self.assertEqual(result, {"text": "hello from replicate"})
+        self.assertEqual(run.call_args.args[0], "openai/whisper")
+        self.assertEqual(run.call_args.kwargs["input"]["audio"].name, str(self.audio_path))
+
+    @patch("sapat.transcription.replicate.replicate.run")
+    def test_transcribe_audio_includes_translate_when_enabled(self, run):
+        run.return_value = {"text": "translated text"}
+
+        ReplicateTranscription(temperature=0.3).transcribe_audio(
+            str(self.audio_path), translate=True
+        )
+
+        self.assertTrue(run.call_args.kwargs["input"]["translate"])
+
+    def test_extracts_segment_text_when_output_contains_segments(self):
+        transcriber = ReplicateTranscription(temperature=0.3)
+
+        text = transcriber._extract_transcription_text(
+            {"segments": [{"text": "hello"}, {"text": " world"}]}
+        )
+
+        self.assertEqual(text, "hello world")
+
+    def test_missing_token_raises_clear_error(self):
+        with patch.dict(os.environ, {"REPLICATE_API_TOKEN": ""}, clear=False):
+            transcriber = ReplicateTranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "REPLICATE_API_TOKEN"):
+            transcriber.transcribe_audio(str(self.audio_path))
+
+    def test_rejects_files_over_configured_limit(self):
+        with patch.dict(os.environ, {"REPLICATE_MAX_FILE_SIZE_MB": "0"}, clear=False):
+            transcriber = ReplicateTranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "upload limit"):
+            transcriber.transcribe_audio(str(self.audio_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_replicate_transcription.py
+++ b/tests/test_replicate_transcription.py
@@ -26,18 +26,21 @@ class ReplicateTranscriptionTests(unittest.TestCase):
         self.tmpdir.cleanup()
         self.env_patch.stop()
 
-    @patch("sapat.transcription.replicate.replicate.run")
-    def test_transcribe_audio_returns_text_from_replicate_transcription(self, run):
+    @patch("sapat.transcription.replicate.replicate.Client")
+    def test_transcribe_audio_returns_text_from_replicate_transcription(self, client_cls):
+        run = client_cls.return_value.run
         run.return_value = {"transcription": "hello from replicate"}
 
         result = ReplicateTranscription(temperature=0.3).transcribe_audio(str(self.audio_path))
 
         self.assertEqual(result, {"text": "hello from replicate"})
+        client_cls.assert_called_once_with(api_token="test-token")
         self.assertEqual(run.call_args.args[0], "openai/whisper")
         self.assertEqual(run.call_args.kwargs["input"]["audio"].name, str(self.audio_path))
 
-    @patch("sapat.transcription.replicate.replicate.run")
-    def test_transcribe_audio_includes_translate_when_enabled(self, run):
+    @patch("sapat.transcription.replicate.replicate.Client")
+    def test_transcribe_audio_includes_translate_when_enabled(self, client_cls):
+        run = client_cls.return_value.run
         run.return_value = {"text": "translated text"}
 
         ReplicateTranscription(temperature=0.3).transcribe_audio(
@@ -45,6 +48,16 @@ class ReplicateTranscriptionTests(unittest.TestCase):
         )
 
         self.assertTrue(run.call_args.kwargs["input"]["translate"])
+
+    @patch("sapat.transcription.replicate.replicate.Client")
+    def test_transcribe_audio_includes_optional_whisper_model(self, client_cls):
+        run = client_cls.return_value.run
+        run.return_value = {"text": "text"}
+
+        with patch.dict(os.environ, {"REPLICATE_WHISPER_MODEL": "large-v3"}, clear=False):
+            ReplicateTranscription(temperature=0.3).transcribe_audio(str(self.audio_path))
+
+        self.assertEqual(run.call_args.kwargs["input"]["model"], "large-v3")
 
     def test_extracts_segment_text_when_output_contains_segments(self):
         transcriber = ReplicateTranscription(temperature=0.3)
@@ -68,6 +81,20 @@ class ReplicateTranscriptionTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "upload limit"):
             transcriber.transcribe_audio(str(self.audio_path))
+
+    def test_rejects_unsupported_audio_extension(self):
+        bad_path = Path(self.tmpdir.name) / "sample.txt"
+        bad_path.write_text("not audio")
+        transcriber = ReplicateTranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "Unsupported audio file format"):
+            transcriber.transcribe_audio(str(bad_path))
+
+    def test_unsupported_output_shape_raises_clear_error(self):
+        transcriber = ReplicateTranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "Unsupported Replicate transcription output"):
+            transcriber._extract_transcription_text({"segments": [{"timestamp": [0, 1]}]})
 
 
 if __name__ == "__main__":

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -20,7 +20,9 @@ class ScriptTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         transcriber_cls.assert_called_once_with(temperature=0.3)
-        transcriber.process_file.assert_called_once()
+        transcriber.process_file.assert_called_once_with(
+            video_path, "en", None, 0.3, "M", False
+        )
 
     def test_replicate_api_rejects_correct_flag(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,39 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+
+
+class ScriptTests(unittest.TestCase):
+    @patch("sapat.script.ReplicateTranscription")
+    def test_replicate_api_choice_wires_replicate_transcriber(self, transcriber_cls):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = Path(tmpdir) / "sample.mp4"
+            video_path.write_bytes(b"fake video")
+            transcriber = transcriber_cls.return_value
+
+            result = CliRunner().invoke(main, [str(video_path), "--api", "replicate"])
+
+        self.assertEqual(result.exit_code, 0)
+        transcriber_cls.assert_called_once_with(temperature=0.3)
+        transcriber.process_file.assert_called_once()
+
+    def test_replicate_api_rejects_correct_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = Path(tmpdir) / "sample.mp4"
+            video_path.write_bytes(b"fake video")
+
+            result = CliRunner().invoke(
+                main, [str(video_path), "--api", "replicate", "--correct"]
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Transcript correction is not supported", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Replicate-backed transcription provider selectable with `--api replicate`
- document Replicate environment variables and usage notes in the README
- add unit coverage for provider output parsing, token/size validation, CLI wiring, and the unsupported `--correct` path

## Validation
- `python3 -m compileall -q src tests`
- `.venv/bin/python -m pip install -q -e .`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m unittest discover -s tests -v`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m sapat.script --help`
- `git diff --check`

Companion implementation for the Daytona content bounty around extending Sapat with additional transcription APIs.
