### PR TITLE
Add NVIDIA ASR NIM transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, NVIDIA ASR NIM, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, NVIDIA ASR NIM, and OpenAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -17,6 +17,7 @@ This tool automates the process of transcribing video files using multiple trans
 - API access for one or more supported services:
   - Azure OpenAI API
   - Groq Cloud API
+  - NVIDIA ASR NIM API
   - OpenAI API
 
 ## Installation
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # NVIDIA ASR NIM
+   NVIDIA_NIM_API_KEY=your_nvidia_api_key_here
+   NVIDIA_NIM_BASE_URL=https://integrate.api.nvidia.com/v1
+   NVIDIA_NIM_MODEL=nvidia/parakeet-ctc-0.6b-asr
    ```
 
 ## Building and Installing the Package
@@ -114,6 +120,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
 - `--api`: Specify the API to use for transcription.
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
+   - `--api nvidia` for NVIDIA ASR NIM
    - `--api openai` for OpenAI API
 
 Example:

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -2,6 +2,7 @@ import click
 from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
+from .transcription.nvidia import NvidiaTranscription
 from .transcription.openai import OpenAITranscription
 
 @click.command()
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'nvidia'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure', or 'nvidia')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -26,6 +27,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = GroqCloudTranscription(temperature=temperature)
     elif api.lower() == "azure":
         transcriber = AzureTranscription(temperature=temperature)
+    elif api.lower() == "nvidia":
+        transcriber = NvidiaTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
     else:

--- a/src/sapat/transcription/nvidia.py
+++ b/src/sapat/transcription/nvidia.py
@@ -1,0 +1,96 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+# Load environment variables
+load_dotenv(".env")
+
+
+class NvidiaTranscription(TranscriptionBase):
+    """
+    NVIDIA ASR NIM implementation for transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the NvidiaTranscription class.
+
+        Parameters:
+        - temperature (float): Default temperature value for transcription.
+        - response_format (str): Default response format for transcription.
+        """
+        self.api_key = os.getenv("NVIDIA_NIM_API_KEY")
+        self.endpoint = os.getenv(
+            "NVIDIA_NIM_BASE_URL",
+            "https://integrate.api.nvidia.com/v1",
+        ).rstrip("/")
+        self.model = os.getenv("NVIDIA_NIM_MODEL", "nvidia/parakeet-ctc-0.6b-asr")
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using the NVIDIA ASR NIM OpenAI-compatible API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_configuration()
+        self._validate_audio_file(audio_file)
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        data = {
+            "model": kwargs.get("model", self.model),
+            "response_format": kwargs.get("response_format", self.response_format),
+        }
+
+        if "language" in kwargs:
+            data["language"] = kwargs["language"]
+        if "prompt" in kwargs:
+            data["prompt"] = kwargs["prompt"]
+
+        with open(audio_file, "rb") as f:
+            files = {"file": f}
+            response = requests.post(
+                f"{self.endpoint}/audio/transcriptions",
+                headers=headers,
+                data=data,
+                files=files,
+            )
+
+        if response.status_code == 200:
+            if data["response_format"] in ["json", "verbose_json"]:
+                return response.json()
+            return response.text
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def _validate_configuration(self):
+        if not self.api_key:
+            raise ValueError("NVIDIA_NIM_API_KEY is required for NVIDIA transcription.")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(
+                f"File size exceeds the maximum limit of {self.max_file_size_mb} MB."
+            )
+
+        valid_extensions = [".mp3", ".wav", ".flac"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/tests/test_nvidia_transcription.py
+++ b/tests/test_nvidia_transcription.py
@@ -1,0 +1,58 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from sapat.transcription.nvidia import NvidiaTranscription
+
+
+class NvidiaTranscriptionTests(unittest.TestCase):
+    def test_requires_api_key(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            transcriber = NvidiaTranscription(temperature=0.3)
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            with self.assertRaisesRegex(ValueError, "NVIDIA_NIM_API_KEY"):
+                transcriber.transcribe_audio(audio.name)
+
+    def test_posts_audio_to_nim_endpoint(self):
+        response = mock.Mock(status_code=200)
+        response.json.return_value = {"text": "hello from parakeet"}
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "NVIDIA_NIM_API_KEY": "test-key",
+                "NVIDIA_NIM_BASE_URL": "https://example.test/v1/",
+                "NVIDIA_NIM_MODEL": "nvidia/parakeet-ctc-0.6b-asr",
+            },
+            clear=True,
+        ):
+            transcriber = NvidiaTranscription(temperature=0.3)
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"audio")
+            audio.flush()
+            with mock.patch("sapat.transcription.nvidia.requests.post", return_value=response) as post:
+                result = transcriber.transcribe_audio(audio.name, language="en")
+
+        self.assertEqual(result, {"text": "hello from parakeet"})
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        self.assertEqual(post.call_args.args[0], "https://example.test/v1/audio/transcriptions")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(kwargs["data"]["model"], "nvidia/parakeet-ctc-0.6b-asr")
+        self.assertEqual(kwargs["data"]["language"], "en")
+        self.assertIn("file", kwargs["files"])
+
+    def test_rejects_unsupported_audio_extension(self):
+        with mock.patch.dict(os.environ, {"NVIDIA_NIM_API_KEY": "test-key"}, clear=True):
+            transcriber = NvidiaTranscription(temperature=0.3)
+
+        with tempfile.NamedTemporaryFile(suffix=".txt") as audio:
+            with self.assertRaisesRegex(ValueError, "Unsupported audio file format"):
+                transcriber.transcribe_audio(audio.name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add an NVIDIA ASR NIM provider wired as `--api nvidia`
- Use environment-driven `NVIDIA_NIM_API_KEY`, `NVIDIA_NIM_BASE_URL`, and `NVIDIA_NIM_MODEL` configuration
- Document the new provider in the README and add focused stdlib tests for configuration, request construction, and validation

## Test plan
- `PYTHONPATH=src python3 -m unittest discover -s tests`
- `PYTHONPATH=src python3 -m py_compile src/sapat/script.py src/sapat/transcription/nvidia.py tests/test_nvidia_transcription.py`