### PR TITLE
feat: add Gemini transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+GEMINI_API_KEY=your_g...here
+GEMINI_MODEL=gemini-2.0-flash
+GEMINI_API_ENDPOINT_TEMPLATE=https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Google Gemini, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Google Gemini, Groq, and OpenAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -16,6 +16,7 @@ This tool automates the process of transcribing video files using multiple trans
 - ffmpeg installed and available in the system PATH
 - API access for one or more supported services:
   - Azure OpenAI API
+  - Google Gemini Developer API
   - Groq Cloud API
   - OpenAI API
 
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Google Gemini
+   GEMINI_API_KEY=your_gemini_api_key_here
+   GEMINI_MODEL=gemini-2.0-flash
+   GEMINI_API_ENDPOINT_TEMPLATE=https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
    ```
 
 ## Building and Installing the Package
@@ -113,6 +119,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
 - `--quality`: Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M').
 - `--api`: Specify the API to use for transcription.
    - `--api azure` for Azure OpenAI API
+   - `--api gemini` for Google Gemini Developer API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
 
@@ -129,7 +136,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Google Gemini, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -2,6 +2,7 @@ import click
 from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
+from .transcription.gemini import GeminiTranscription
 from .transcription.openai import OpenAITranscription
 
 @click.command()
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'gemini'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'gemini')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -26,6 +27,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = GroqCloudTranscription(temperature=temperature)
     elif api.lower() == "azure":
         transcriber = AzureTranscription(temperature=temperature)
+    elif api.lower() == "gemini":
+        transcriber = GeminiTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
     else:

--- a/src/sapat/transcription/gemini.py
+++ b/src/sapat/transcription/gemini.py
@@ -1,0 +1,245 @@
+import base64
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class GeminiTranscription(TranscriptionBase):
+    """
+    Google Gemini Developer API implementation for transcription.
+    """
+
+    DEFAULT_MODEL = "gemini-2.0-flash"
+    DEFAULT_ENDPOINT_TEMPLATE = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "{model}:generateContent"
+    )
+    MIME_TYPES = {
+        ".mp3": "audio/mp3",
+        ".wav": "audio/wav",
+        ".flac": "audio/flac",
+    }
+
+    def __init__(self, temperature: float, response_format: str = "text"):
+        """
+        Initializes the GeminiTranscription class.
+
+        Parameters:
+        - temperature (float): Default temperature value for transcription.
+        - response_format (str): Present for consistency with other providers.
+        """
+        self.api_key = os.getenv("GEMINI_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "GEMINI_API_KEY is required to use the Gemini transcription API."
+            )
+
+        self.model = os.getenv("GEMINI_MODEL") or self.DEFAULT_MODEL
+        self.endpoint_template = (
+            os.getenv("GEMINI_API_ENDPOINT_TEMPLATE")
+            or self.DEFAULT_ENDPOINT_TEMPLATE
+        )
+        self.temperature = temperature
+        self.response_format = response_format
+        # Gemini inline requests must stay under the request-size limit. Base64
+        # expands audio by roughly 33%, so Sapat keeps raw files below 14 MB.
+        self.max_raw_file_size_mb = 14
+        self.timeout_seconds = 120
+
+    def transcribe_audio(self, audio_file: str, **kwargs: Any) -> str:
+        """
+        Transcribes an audio file using Gemini generateContent with inline audio.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Optional language, prompt, model, temperature, and timeout.
+
+        Returns:
+        - str: The transcription text.
+        """
+        audio_path = self._validate_audio_file(audio_file)
+        model = kwargs.get("model", self.model)
+        url = self._build_endpoint(model)
+        prompt = self._build_prompt(
+            language=kwargs.get("language"), user_prompt=kwargs.get("prompt")
+        )
+        mime_type = self.MIME_TYPES[audio_path.suffix.lower()]
+        inline_audio = self._encode_audio(audio_path)
+
+        payload = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"text": prompt},
+                        {
+                            "inline_data": {
+                                "mime_type": mime_type,
+                                "data": inline_audio,
+                            }
+                        },
+                    ],
+                }
+            ],
+            "generationConfig": {
+                "temperature": kwargs.get("temperature", self.temperature),
+            },
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "x-goog-api-key": self.api_key,
+        }
+
+        try:
+            response = requests.post(
+                url,
+                headers=headers,
+                json=payload,
+                timeout=kwargs.get("timeout", self.timeout_seconds),
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(
+                f"Gemini transcription request failed: {exc}"
+            ) from exc
+
+        response_payload = self._decode_response_json(response)
+        if not 200 <= response.status_code < 300:
+            error_message = self._extract_error_message(response_payload, response.text)
+            raise RuntimeError(
+                "Gemini transcription failed with status "
+                f"{response.status_code}: {error_message}"
+            )
+
+        return self._extract_transcription_text(response_payload)
+
+    def generate_corrected_transcript(
+        self, audio_file: str, temperature: float, system_prompt: str
+    ) -> str:
+        """
+        Re-transcribes audio with Gemini while asking for light transcript cleanup.
+        """
+        correction_prompt = (
+            "First transcribe the audio faithfully. Then apply only light cleanup: "
+            "fix obvious spelling, capitalization, and punctuation mistakes without "
+            "adding new content.\n"
+            f"Correction guidance: {system_prompt}"
+        )
+        return self.transcribe_audio(
+            audio_file,
+            temperature=temperature,
+            prompt=correction_prompt,
+        )
+
+    def _validate_audio_file(self, audio_file: str) -> Path:
+        audio_path = Path(audio_file)
+        if not audio_path.exists():
+            raise FileNotFoundError(f"File {audio_file} does not exist.")
+        if not audio_path.is_file():
+            raise ValueError(f"Path {audio_file} is not a file.")
+
+        valid_extensions = sorted(self.MIME_TYPES.keys())
+        if audio_path.suffix.lower() not in self.MIME_TYPES:
+            raise ValueError(
+                "Unsupported audio file format: "
+                f"{audio_file}. Supported formats are {valid_extensions}."
+            )
+
+        file_size_mb = audio_path.stat().st_size / (1024 * 1024)
+        if file_size_mb > self.max_raw_file_size_mb:
+            raise ValueError(
+                "File size exceeds Sapat's conservative Gemini inline audio "
+                f"limit of {self.max_raw_file_size_mb} MB. Split the audio "
+                "or use a provider flow that supports uploaded files."
+            )
+
+        return audio_path
+
+    def _build_endpoint(self, model: str) -> str:
+        try:
+            return self.endpoint_template.format(model=model)
+        except KeyError as exc:
+            raise ValueError(
+                "GEMINI_API_ENDPOINT_TEMPLATE may only use the {model} placeholder."
+            ) from exc
+
+    def _build_prompt(
+        self, language: Optional[str] = None, user_prompt: Optional[str] = None
+    ) -> str:
+        prompt_parts = [
+            "Transcribe the provided audio as accurately as possible.",
+            "Return only the transcription text.",
+        ]
+        if language:
+            prompt_parts.append(f"Language: {language}.")
+        if user_prompt:
+            prompt_parts.append(f"Additional transcription guidance: {user_prompt}")
+        return "\n".join(prompt_parts)
+
+    def _encode_audio(self, audio_path: Path) -> str:
+        with open(audio_path, "rb") as audio:
+            return base64.b64encode(audio.read()).decode("ascii")
+
+    def _decode_response_json(self, response: requests.Response) -> Dict[str, Any]:
+        try:
+            return response.json()
+        except ValueError as exc:
+            if not 200 <= response.status_code < 300:
+                raise RuntimeError(
+                    "Gemini transcription failed with status "
+                    f"{response.status_code}: {response.text}"
+                ) from exc
+            raise RuntimeError(
+                "Gemini transcription returned a non-JSON response: "
+                f"{response.text}"
+            ) from exc
+
+    def _extract_error_message(
+        self, response_payload: Dict[str, Any], fallback: str
+    ) -> str:
+        error = response_payload.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if message:
+                return str(message)
+        if response_payload:
+            return str(response_payload)
+        return fallback or "unknown error"
+
+    def _extract_transcription_text(self, response_payload: Dict[str, Any]) -> str:
+        candidates = response_payload.get("candidates") or []
+        if not candidates:
+            prompt_feedback = response_payload.get("promptFeedback")
+            if prompt_feedback:
+                raise RuntimeError(
+                    "Gemini transcription returned no candidates. "
+                    f"Prompt feedback: {prompt_feedback}"
+                )
+            raise RuntimeError("Gemini transcription returned no candidates.")
+
+        content = candidates[0].get("content") or {}
+        parts = content.get("parts") or []
+        texts = []
+        for part in parts:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    texts.append(text.strip())
+
+        transcription = "\n".join(texts).strip()
+        if not transcription:
+            finish_reason = candidates[0].get("finishReason")
+            message = "Gemini transcription returned an empty response."
+            if finish_reason:
+                message += f" Finish reason: {finish_reason}."
+            raise RuntimeError(message)
+
+        return transcription

--- a/tests/test_gemini.py
+++ b/tests/test_gemini.py
@@ -1,0 +1,278 @@
+import ast
+import base64
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import requests
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from sapat.transcription.gemini import GeminiTranscription
+
+
+def ast_string_value(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Str):
+        return node.s
+    return None
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class GeminiTranscriptionTests(unittest.TestCase):
+    def _temporary_audio_file(self, suffix=".mp3", content=b"audio bytes"):
+        temp_file = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        try:
+            temp_file.write(content)
+            return temp_file.name
+        finally:
+            temp_file.close()
+            self.addCleanup(self._remove_file, temp_file.name)
+
+    def _remove_file(self, path):
+        if os.path.exists(path):
+            os.remove(path)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_request_construction_uses_inline_base64_audio(self, mock_post):
+        audio_content = b"example audio"
+        audio_file = self._temporary_audio_file(".mp3", audio_content)
+        mock_post.return_value = FakeResponse(
+            200,
+            {
+                "candidates": [
+                    {"content": {"parts": [{"text": "hola mundo"}]}}
+                ]
+            },
+        )
+
+        result = GeminiTranscription(temperature=0.2).transcribe_audio(
+            audio_file,
+            language="es",
+            prompt="Speaker says Sapat.",
+        )
+
+        self.assertEqual(result, "hola mundo")
+        mock_post.assert_called_once()
+        request_url = mock_post.call_args[0][0]
+        request_kwargs = mock_post.call_args[1]
+        request_json = request_kwargs["json"]
+        parts = request_json["contents"][0]["parts"]
+
+        self.assertEqual(
+            request_url,
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            "gemini-2.0-flash:generateContent",
+        )
+        self.assertEqual(request_kwargs["headers"]["x-goog-api-key"], "test-key")
+        self.assertEqual(request_kwargs["headers"]["Content-Type"], "application/json")
+        self.assertEqual(request_json["generationConfig"]["temperature"], 0.2)
+        self.assertIn("Language: es.", parts[0]["text"])
+        self.assertIn("Speaker says Sapat.", parts[0]["text"])
+        self.assertEqual(parts[1]["inline_data"]["mime_type"], "audio/mp3")
+        self.assertEqual(
+            parts[1]["inline_data"]["data"],
+            base64.b64encode(audio_content).decode("ascii"),
+        )
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_response_parsing_concatenates_text_parts(self, mock_post):
+        audio_file = self._temporary_audio_file(".wav")
+        mock_post.return_value = FakeResponse(
+            200,
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"text": " first part "},
+                                {"inline_data": {"mime_type": "audio/wav"}},
+                                {"text": "second part"},
+                            ]
+                        }
+                    }
+                ]
+            },
+        )
+
+        result = GeminiTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+        self.assertEqual(result, "first part\nsecond part")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_missing_api_key_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "GEMINI_API_KEY"):
+            GeminiTranscription(temperature=0.3)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_validation_rejects_missing_unsupported_and_large_files(self, mock_post):
+        transcriber = GeminiTranscription(temperature=0.3)
+
+        with self.assertRaises(FileNotFoundError):
+            transcriber.transcribe_audio("/tmp/does-not-exist.mp3")
+
+        unsupported_file = self._temporary_audio_file(".ogg")
+        with self.assertRaisesRegex(ValueError, "Unsupported audio file format"):
+            transcriber.transcribe_audio(unsupported_file)
+
+        large_file = self._temporary_audio_file(".mp3", b"")
+        with open(large_file, "wb") as handle:
+            handle.seek(14 * 1024 * 1024)
+            handle.write(b"x")
+        with self.assertRaisesRegex(ValueError, "Gemini inline audio limit"):
+            transcriber.transcribe_audio(large_file)
+
+        mock_post.assert_not_called()
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_api_error_raises_helpful_exception(self, mock_post):
+        audio_file = self._temporary_audio_file(".flac")
+        mock_post.return_value = FakeResponse(
+            400,
+            {"error": {"message": "API key not valid"}},
+            text='{"error": {"message": "API key not valid"}}',
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "API key not valid"):
+            GeminiTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_empty_response_raises_helpful_exception(self, mock_post):
+        audio_file = self._temporary_audio_file(".mp3")
+        mock_post.return_value = FakeResponse(
+            200,
+            {
+                "candidates": [
+                    {"content": {"parts": []}, "finishReason": "STOP"}
+                ]
+            },
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "empty response"):
+            GeminiTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_request_exception_is_wrapped(self, mock_post):
+        audio_file = self._temporary_audio_file(".mp3")
+        mock_post.side_effect = requests.RequestException("timeout")
+
+        with self.assertRaisesRegex(RuntimeError, "request failed: timeout"):
+            GeminiTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_non_json_response_is_rejected(self, mock_post):
+        audio_file = self._temporary_audio_file(".mp3")
+        mock_post.return_value = FakeResponse(200, ValueError("not json"), text="oops")
+
+        with self.assertRaisesRegex(RuntimeError, "non-JSON response"):
+            GeminiTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_prompt_feedback_error_is_reported(self, mock_post):
+        audio_file = self._temporary_audio_file(".mp3")
+        mock_post.return_value = FakeResponse(
+            200,
+            {"candidates": [], "promptFeedback": {"blockReason": "SAFETY"}},
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Prompt feedback"):
+            GeminiTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+    @patch.dict(
+        os.environ,
+        {
+            "GEMINI_API_KEY": "test-key",
+            "GEMINI_MODEL": "gemini-1.5-flash",
+            "GEMINI_API_ENDPOINT_TEMPLATE": "https://example.test/{model}",
+        },
+        clear=True,
+    )
+    @patch("sapat.transcription.gemini.requests.post")
+    def test_custom_model_and_endpoint_template_are_used(self, mock_post):
+        audio_file = self._temporary_audio_file(".mp3")
+        mock_post.return_value = FakeResponse(
+            200,
+            {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]},
+        )
+
+        GeminiTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+        self.assertEqual(mock_post.call_args[0][0], "https://example.test/gemini-1.5-flash")
+
+    @patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.transcription.gemini.GeminiTranscription.transcribe_audio")
+    def test_generate_corrected_transcript_uses_gemini_prompt(self, mock_transcribe):
+        mock_transcribe.return_value = "clean transcript"
+        result = GeminiTranscription(temperature=0.3).generate_corrected_transcript(
+            "clip.mp3", 0.7, "Keep product names correct."
+        )
+
+        self.assertEqual(result, "clean transcript")
+        _, kwargs = mock_transcribe.call_args
+        self.assertEqual(kwargs["temperature"], 0.7)
+        self.assertIn("light cleanup", kwargs["prompt"])
+        self.assertIn("Keep product names correct.", kwargs["prompt"])
+
+
+class GeminiCliTests(unittest.TestCase):
+    def test_cli_choice_includes_gemini(self):
+        script_path = ROOT / "src" / "sapat" / "script.py"
+        source = script_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        main_function = next(
+            node for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "main"
+        )
+
+        api_choices = None
+        for decorator in main_function.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            if not getattr(decorator.func, "attr", None) == "option":
+                continue
+            option_names = [ast_string_value(arg) for arg in decorator.args]
+            if "--api" not in option_names:
+                continue
+            for keyword in decorator.keywords:
+                if keyword.arg == "type" and isinstance(keyword.value, ast.Call):
+                    choice_args = keyword.value.args
+                    if choice_args and isinstance(
+                        choice_args[0], (ast.List, ast.Tuple)
+                    ):
+                        api_choices = [
+                            ast_string_value(item) for item in choice_args[0].elts
+                        ]
+
+        self.assertIsNotNone(api_choices)
+        self.assertIn("gemini", api_choices)
+        self.assertIn('elif api.lower() == "gemini":', source)
+        self.assertIn("GeminiTranscription(temperature=temperature)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a Google Gemini Developer API transcription backend available through `--api gemini`.
- Sends converted audio as inline base64 to Gemini `generateContent` with `GEMINI_API_KEY`, optional `GEMINI_MODEL`, and no new runtime dependencies.
- Documents Gemini environment variables and usage in the README.
- Adds mocked unittest coverage for request construction, response parsing, validation, CLI routing, and error paths.

## Why
This supports daytonaio/content#13 by adding a new non-overlapping Sapat provider for a companion Daytona guide.

## Validation
- `python -m venv .venv && .venv/bin/python -m pip install -q -e .`
- `.venv/bin/python -m unittest discover -s tests -v` (12 tests)
- `.venv/bin/python -m compileall src tests`
- `git diff --check`

AI-assisted with Codex and reviewed with Claude Code; I inspected and validated the final diff locally.