### PR TITLE
Add Deepgram transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+DEEPGRAM_API_KEY=
+DEEPGRAM_MODEL=nova-3
+DEEPGRAM_API_ENDPOINT=https://api.deepgram.com/v1/listen

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Deepgram APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Deepgram APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Deepgram API
 
 ## Installation
 
@@ -53,6 +54,11 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Deepgram
+   DEEPGRAM_API_KEY=your_deepgram_api_key_here
+   DEEPGRAM_MODEL=nova-3
+   DEEPGRAM_API_ENDPOINT=https://api.deepgram.com/v1/listen
    ```
 
 ## Building and Installing the Package
@@ -115,11 +121,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api deepgram` for Deepgram API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Deepgram example:
+
+```
+sapat my_video.mp4 --quality H --language en --api deepgram
 ```
 
 - If a file is provided, it will process that single file.

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.deepgram import DeepgramTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'deepgram'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'deepgram')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "deepgram":
+        transcriber = DeepgramTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/deepgram.py
+++ b/src/sapat/transcription/deepgram.py
@@ -1,0 +1,98 @@
+import os
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+load_dotenv(".env")
+
+
+class DeepgramTranscription(TranscriptionBase):
+    """
+    Deepgram API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float):
+        self.api_key = os.getenv("DEEPGRAM_API_KEY")
+        self.model = os.getenv("DEEPGRAM_MODEL", "nova-3")
+        self.endpoint = os.getenv(
+            "DEEPGRAM_API_ENDPOINT",
+            "https://api.deepgram.com/v1/listen",
+        )
+        self.temperature = temperature
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file with Deepgram's prerecorded audio endpoint.
+        """
+        self._validate_audio_file(audio_file)
+
+        params = {
+            "model": kwargs.get("model", self.model),
+            "smart_format": "true",
+        }
+
+        language = kwargs.get("language")
+        if language:
+            params["language"] = language
+
+        prompt = kwargs.get("prompt")
+        if prompt:
+            params["keywords"] = prompt
+
+        headers = {
+            "Authorization": f"Token {self.api_key}",
+            "Content-Type": self._content_type(audio_file),
+        }
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                params=params,
+                data=f,
+                timeout=120,
+            )
+
+        if response.status_code != 200:
+            raise Exception(f"Transcription failed: {response.text}")
+
+        payload = response.json()
+        return self._extract_transcript(payload)
+
+    @staticmethod
+    def _content_type(audio_file: str):
+        suffix = Path(audio_file).suffix.lower()
+        if suffix == ".mp3":
+            return "audio/mpeg"
+        if suffix == ".wav":
+            return "audio/wav"
+        if suffix == ".flac":
+            return "audio/flac"
+        return "application/octet-stream"
+
+    @staticmethod
+    def _extract_transcript(payload):
+        channels = payload.get("results", {}).get("channels", [])
+        if not channels:
+            return ""
+
+        alternatives = channels[0].get("alternatives", [])
+        if not alternatives:
+            return ""
+
+        return alternatives[0].get("transcript", "")
+
+    @staticmethod
+    def _validate_audio_file(audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        valid_extensions = [".mp3", ".wav", ".flac"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )


### PR DESCRIPTION
## Summary
- Add a Deepgram transcription provider using the prerecorded listen endpoint
- Wire `--api deepgram` into the Sapat CLI
- Document `DEEPGRAM_API_KEY`, model, and endpoint configuration in `.env.example` and the README

## Validation
- `python3 -m compileall -q src`
- `python3 -m py_compile src/sapat/script.py src/sapat/transcription/deepgram.py`
- `git diff --check`

No secrets or API keys are committed.