### PR TITLE
Add Sarvam AI transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ SARVAM_API_KEY=
 SARVAM_STT_ENDPOINT=https://api.sarvam.ai/speech-to-text
 SARVAM_STT_MODEL=saaras:v3
 SARVAM_STT_MODE=transcribe
-SARVAM_LANGUAGE_CODE=unknown
+SARVAM_LANGUAGE_CODE=

--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+SARVAM_API_KEY=
+SARVAM_STT_ENDPOINT=https://api.sarvam.ai/speech-to-text
+SARVAM_STT_MODEL=saaras:v3
+SARVAM_STT_MODE=transcribe
+SARVAM_LANGUAGE_CODE=unknown

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This tool automates the process of transcribing video files using multiple trans
    SARVAM_STT_ENDPOINT=https://api.sarvam.ai/speech-to-text
    SARVAM_STT_MODEL=saaras:v3
    SARVAM_STT_MODE=transcribe
-   SARVAM_LANGUAGE_CODE=unknown
+   SARVAM_LANGUAGE_CODE=
    ```
 
 ## Building and Installing the Package
@@ -131,7 +131,7 @@ Example:
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
 ```
 
-Sarvam AI uses BCP-47 language codes for speech-to-text. You can pass common short codes such as `--language hi`, `--language ta`, or `--language en`, and Sapat maps them to Sarvam's `hi-IN`, `ta-IN`, and `en-IN` codes. Use `--language unknown` or set `SARVAM_LANGUAGE_CODE=unknown` for Sarvam language detection.
+Sarvam AI uses BCP-47 language codes for speech-to-text. You can pass common short codes such as `--language hi`, `--language ta`, or `--language en`, and Sapat maps them to Sarvam's `hi-IN`, `ta-IN`, and `en-IN` codes. Use `--language unknown` for Sarvam language detection, or set `SARVAM_LANGUAGE_CODE` when you want one fallback language code for every run.
 
 - If a file is provided, it will process that single file.
 - If a directory is provided, it will process all `.mp4` files in that directory.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Sarvam AI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Sarvam AI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Sarvam AI API
 
 ## Installation
 
@@ -53,6 +54,13 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Sarvam AI
+   SARVAM_API_KEY=your_sarvam_api_key_here
+   SARVAM_STT_ENDPOINT=https://api.sarvam.ai/speech-to-text
+   SARVAM_STT_MODEL=saaras:v3
+   SARVAM_STT_MODE=transcribe
+   SARVAM_LANGUAGE_CODE=unknown
    ```
 
 ## Building and Installing the Package
@@ -115,12 +123,15 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api sarvam` for Sarvam AI API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
 ```
+
+Sarvam AI uses BCP-47 language codes for speech-to-text. You can pass common short codes such as `--language hi`, `--language ta`, or `--language en`, and Sapat maps them to Sarvam's `hi-IN`, `ta-IN`, and `en-IN` codes. Use `--language unknown` or set `SARVAM_LANGUAGE_CODE=unknown` for Sarvam language detection.
 
 - If a file is provided, it will process that single file.
 - If a directory is provided, it will process all `.mp4` files in that directory.
@@ -129,7 +140,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Sarvam AI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.sarvam import SarvamTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'sarvam'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'sarvam')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "sarvam":
+        transcriber = SarvamTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/sarvam.py
+++ b/src/sapat/transcription/sarvam.py
@@ -48,10 +48,10 @@ class SarvamTranscription(TranscriptionBase):
         - temperature (float): Accepted for CLI compatibility with other providers.
         """
         self.api_key = os.getenv("SARVAM_API_KEY")
-        self.endpoint = os.getenv("SARVAM_STT_ENDPOINT", "https://api.sarvam.ai/speech-to-text")
-        self.model = os.getenv("SARVAM_STT_MODEL", "saaras:v3")
-        self.mode = os.getenv("SARVAM_STT_MODE", "transcribe")
-        self.default_language_code = os.getenv("SARVAM_LANGUAGE_CODE")
+        self.endpoint = os.getenv("SARVAM_STT_ENDPOINT") or "https://api.sarvam.ai/speech-to-text"
+        self.model = os.getenv("SARVAM_STT_MODEL") or "saaras:v3"
+        self.mode = os.getenv("SARVAM_STT_MODE") or "transcribe"
+        self.default_language_code = os.getenv("SARVAM_LANGUAGE_CODE") or None
         self.temperature = temperature
 
     def transcribe_audio(self, audio_file: str, **kwargs):
@@ -96,7 +96,7 @@ class SarvamTranscription(TranscriptionBase):
         return payload
 
     def _language_code(self, language):
-        language = self.default_language_code or language
+        language = language or self.default_language_code
         if not language:
             return None
 

--- a/src/sapat/transcription/sarvam.py
+++ b/src/sapat/transcription/sarvam.py
@@ -1,0 +1,138 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class SarvamTranscription(TranscriptionBase):
+    """
+    Sarvam AI implementation for speech-to-text transcription.
+    """
+
+    LANGUAGE_ALIASES = {
+        "as": "as-IN",
+        "bn": "bn-IN",
+        "brx": "brx-IN",
+        "doi": "doi-IN",
+        "en": "en-IN",
+        "gu": "gu-IN",
+        "hi": "hi-IN",
+        "kn": "kn-IN",
+        "kok": "kok-IN",
+        "ks": "ks-IN",
+        "mai": "mai-IN",
+        "ml": "ml-IN",
+        "mni": "mni-IN",
+        "mr": "mr-IN",
+        "ne": "ne-IN",
+        "od": "od-IN",
+        "pa": "pa-IN",
+        "sa": "sa-IN",
+        "sat": "sat-IN",
+        "sd": "sd-IN",
+        "ta": "ta-IN",
+        "te": "te-IN",
+        "ur": "ur-IN",
+    }
+
+    def __init__(self, temperature: float):
+        """
+        Initializes the SarvamTranscription class.
+
+        Parameters:
+        - temperature (float): Accepted for CLI compatibility with other providers.
+        """
+        self.api_key = os.getenv("SARVAM_API_KEY")
+        self.endpoint = os.getenv("SARVAM_STT_ENDPOINT", "https://api.sarvam.ai/speech-to-text")
+        self.model = os.getenv("SARVAM_STT_MODEL", "saaras:v3")
+        self.mode = os.getenv("SARVAM_STT_MODE", "transcribe")
+        self.default_language_code = os.getenv("SARVAM_LANGUAGE_CODE")
+        self.temperature = temperature
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Sarvam AI's speech-to-text REST API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional transcription parameters.
+
+        Returns:
+        - dict: The Sarvam response with a text alias for Sapat's writer.
+        """
+        self._validate_audio_file(audio_file)
+
+        if not self.api_key:
+            raise ValueError("SARVAM_API_KEY is required for Sarvam transcription.")
+
+        data = {
+            "model": kwargs.get("model", self.model),
+            "mode": kwargs.get("mode", self.mode),
+        }
+
+        language_code = self._language_code(kwargs.get("language"))
+        if language_code:
+            data["language_code"] = language_code
+
+        headers = {
+            "api-subscription-key": self.api_key,
+        }
+
+        with open(audio_file, "rb") as f:
+            files = {"file": f}
+            response = requests.post(self.endpoint, headers=headers, data=data, files=files)
+
+        if response.status_code != 200:
+            raise Exception(f"Transcription failed: {response.text}")
+
+        payload = response.json()
+        transcript = payload.get("transcript", "")
+        payload["text"] = transcript
+        return payload
+
+    def _language_code(self, language):
+        language = self.default_language_code or language
+        if not language:
+            return None
+
+        normalized = language.strip()
+        if not normalized or normalized.lower() == "auto":
+            return None
+        if normalized.lower() == "unknown":
+            return "unknown"
+        if "-" in normalized:
+            return normalized
+        return self.LANGUAGE_ALIASES.get(normalized.lower(), normalized)
+
+    @staticmethod
+    def _validate_audio_file(audio_file: str):
+        """
+        Validates that the audio file exists and uses a Sarvam-supported extension.
+        """
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        valid_extensions = [
+            ".aac",
+            ".aiff",
+            ".amr",
+            ".flac",
+            ".m4a",
+            ".mp3",
+            ".mp4",
+            ".ogg",
+            ".opus",
+            ".pcm",
+            ".wav",
+            ".webm",
+            ".wma",
+        ]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}."
+            )

--- a/tests/test_sarvam.py
+++ b/tests/test_sarvam.py
@@ -52,6 +52,28 @@ class SarvamTranscriptionTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "SARVAM_API_KEY"):
                     SarvamTranscription(temperature=0.3).transcribe_audio(audio.name)
 
+    def test_cli_language_overrides_env_default(self):
+        with mock.patch.dict(os.environ, {"SARVAM_LANGUAGE_CODE": "unknown"}, clear=False):
+            transcriber = SarvamTranscription(temperature=0.3)
+            self.assertEqual(transcriber._language_code("ta"), "ta-IN")
+
+    def test_blank_optional_env_uses_endpoint_default(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "SARVAM_STT_ENDPOINT": "",
+                "SARVAM_STT_MODEL": "",
+                "SARVAM_STT_MODE": "",
+                "SARVAM_LANGUAGE_CODE": "",
+            },
+            clear=False,
+        ):
+            transcriber = SarvamTranscription(temperature=0.3)
+            self.assertEqual(transcriber.endpoint, "https://api.sarvam.ai/speech-to-text")
+            self.assertEqual(transcriber.model, "saaras:v3")
+            self.assertEqual(transcriber.mode, "transcribe")
+            self.assertIsNone(transcriber.default_language_code)
+
     def test_cli_accepts_sarvam_api_choice(self):
         runner = main.make_context(
             "sapat",

--- a/tests/test_sarvam.py
+++ b/tests/test_sarvam.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from sapat.script import main
+from sapat.transcription.sarvam import SarvamTranscription
+
+
+class SarvamTranscriptionTests(unittest.TestCase):
+    def setUp(self):
+        self.env = mock.patch.dict(
+            os.environ,
+            {
+                "SARVAM_API_KEY": "test-key",
+                "SARVAM_STT_ENDPOINT": "https://api.sarvam.ai/speech-to-text",
+                "SARVAM_STT_MODEL": "saaras:v3",
+                "SARVAM_STT_MODE": "transcribe",
+            },
+            clear=False,
+        )
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+
+    @mock.patch("sapat.transcription.sarvam.requests.post")
+    def test_posts_sarvam_request_and_exposes_text_alias(self, post):
+        post.return_value.status_code = 200
+        post.return_value.json.return_value = {
+            "request_id": "request-123",
+            "transcript": "namaste",
+            "language_code": "hi-IN",
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            result = SarvamTranscription(temperature=0.3).transcribe_audio(
+                audio.name,
+                language="hi",
+            )
+
+        self.assertEqual(result["text"], "namaste")
+        _, kwargs = post.call_args
+        self.assertEqual(kwargs["headers"], {"api-subscription-key": "test-key"})
+        self.assertEqual(kwargs["data"]["model"], "saaras:v3")
+        self.assertEqual(kwargs["data"]["mode"], "transcribe")
+        self.assertEqual(kwargs["data"]["language_code"], "hi-IN")
+
+    def test_missing_api_key_fails_before_request(self):
+        with mock.patch.dict(os.environ, {"SARVAM_API_KEY": ""}, clear=False):
+            with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+                with self.assertRaisesRegex(ValueError, "SARVAM_API_KEY"):
+                    SarvamTranscription(temperature=0.3).transcribe_audio(audio.name)
+
+    def test_cli_accepts_sarvam_api_choice(self):
+        runner = main.make_context(
+            "sapat",
+            ["sample.mp4", "--api", "sarvam"],
+            resilient_parsing=True,
+        )
+        self.assertEqual(runner.params["api"], "sarvam")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Sarvam AI speech-to-text provider using the REST `/speech-to-text` endpoint
- wire `--api sarvam` through the CLI and document the required `.env` settings
- add mocked tests for request construction, missing API key handling, response parsing, and CLI routing

## Validation
- `/tmp/sapat-sarvam-venv/bin/python -m unittest discover -s tests`
- `/tmp/sapat-sarvam-venv/bin/python -m py_compile src/sapat/script.py src/sapat/transcription/*.py tests/test_sarvam.py`
- `/tmp/sapat-sarvam-venv/bin/sapat --help`

Context: companion implementation for daytonaio/content#13.\n## Demo\n- Companion walkthrough video: https://github.com/SadmanPinon/content/blob/sarvam-sapat-transcription-guide/guides/assets/20260521_run_sarvam_transcription_with_sapat_demo.mp4\n- Bounty guide PR with the in-repo demo asset: https://github.com/daytonaio/content/pull/235\n