### PR TITLE
Add offline Vosk transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI APIs, and local Vosk models. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI APIs, and local Vosk models
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Optional local Vosk model directory for offline transcription
 
 ## Installation
 
@@ -53,6 +54,18 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Vosk offline transcription
+   VOSK_MODEL_PATH=/path/to/unpacked/vosk-model-small-en-us-0.15
+   VOSK_SAMPLE_RATE=16000
+   VOSK_CHUNK_SIZE=4000
+   ```
+
+   For Vosk support, install the optional dependency and download a Vosk model
+   from https://alphacephei.com/vosk/models:
+
+   ```
+   pip install "sapat[vosk]"
    ```
 
 ## Building and Installing the Package
@@ -115,11 +128,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api vosk` for offline Vosk transcription
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Offline Vosk example:
+
+```
+sapat my_video.mp4 --quality M --language en --api vosk
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +149,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI) plus local Vosk models. Ensure you have valid API credentials configured in the `.env` file for hosted APIs, or a valid `VOSK_MODEL_PATH` for offline transcription.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "groq>=0.13.1"
 ]
 
+[project.optional-dependencies]
+vosk = [
+    "vosk>=0.3.45"
+]
+
 [project.scripts]
 sapat = "sapat.script:main"
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.vosk import VoskTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'vosk'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'vosk')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "vosk":
+        transcriber = VoskTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/vosk.py
+++ b/src/sapat/transcription/vosk.py
@@ -1,0 +1,93 @@
+import json
+import os
+import subprocess
+import tempfile
+import wave
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+load_dotenv(".env")
+
+
+class VoskTranscription(TranscriptionBase):
+    """
+    Offline Vosk implementation for local transcription.
+    """
+
+    def __init__(self, temperature: float = 0.0):
+        self.model_path = os.getenv("VOSK_MODEL_PATH")
+        self.sample_rate = int(os.getenv("VOSK_SAMPLE_RATE", "16000"))
+        self.chunk_size = int(os.getenv("VOSK_CHUNK_SIZE", "4000"))
+        self.temperature = temperature
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        self._validate_config(audio_file)
+
+        wav_file = self._convert_to_wav(audio_file)
+        try:
+            try:
+                import vosk
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Vosk support requires the optional dependency. "
+                    "Install it with `pip install 'sapat[vosk]'` or `pip install vosk`."
+                ) from exc
+
+            model = vosk.Model(self.model_path)
+            transcript_parts = []
+
+            with wave.open(wav_file, "rb") as audio:
+                recognizer = vosk.KaldiRecognizer(model, audio.getframerate())
+
+                while True:
+                    data = audio.readframes(self.chunk_size)
+                    if len(data) == 0:
+                        break
+                    if recognizer.AcceptWaveform(data):
+                        transcript_parts.append(self._extract_text(recognizer.Result()))
+
+                transcript_parts.append(self._extract_text(recognizer.FinalResult()))
+
+            return {"text": " ".join(part for part in transcript_parts if part).strip()}
+        finally:
+            wav_path = Path(wav_file)
+            if wav_path.exists():
+                wav_path.unlink()
+
+    def _validate_config(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+        if not self.model_path:
+            raise ValueError("VOSK_MODEL_PATH must point to an unpacked Vosk model directory.")
+        if not os.path.isdir(self.model_path):
+            raise ValueError(f"VOSK_MODEL_PATH does not exist or is not a directory: {self.model_path}")
+
+    def _convert_to_wav(self, audio_file: str):
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            wav_path = tmp.name
+
+        command = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            audio_file,
+            "-ac",
+            "1",
+            "-ar",
+            str(self.sample_rate),
+            "-f",
+            "wav",
+            wav_path,
+        ]
+        subprocess.run(command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return wav_path
+
+    @staticmethod
+    def _extract_text(result_json: str):
+        try:
+            return json.loads(result_json).get("text", "")
+        except json.JSONDecodeError:
+            return ""

--- a/tests/test_vosk.py
+++ b/tests/test_vosk.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+import wave
+from pathlib import Path
+from unittest.mock import patch
+
+from sapat.transcription.vosk import VoskTranscription
+
+
+class FakeRecognizer:
+    def __init__(self, model, sample_rate):
+        self.model = model
+        self.sample_rate = sample_rate
+
+    def AcceptWaveform(self, data):
+        return True
+
+    def Result(self):
+        return '{"text": "hello"}'
+
+    def FinalResult(self):
+        return '{"text": "world"}'
+
+
+class VoskTranscriptionTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.model_dir = Path(self.tmpdir.name) / "model"
+        self.model_dir.mkdir()
+        self.audio_file = Path(self.tmpdir.name) / "input.mp3"
+        self.audio_file.write_bytes(b"fake audio")
+        self.wav_file = Path(self.tmpdir.name) / "input.wav"
+        with wave.open(str(self.wav_file), "wb") as audio:
+            audio.setnchannels(1)
+            audio.setsampwidth(2)
+            audio.setframerate(16000)
+            audio.writeframes(b"\x00\x00" * 16)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_transcribes_with_mocked_vosk(self):
+        fake_vosk = types.SimpleNamespace(
+            Model=lambda model_path: {"model_path": model_path},
+            KaldiRecognizer=FakeRecognizer,
+        )
+        original_vosk = sys.modules.get("vosk")
+        sys.modules["vosk"] = fake_vosk
+        self.addCleanup(self._restore_vosk_module, original_vosk)
+
+        with patch.dict(os.environ, {"VOSK_MODEL_PATH": str(self.model_dir)}):
+            transcriber = VoskTranscription()
+            with patch.object(transcriber, "_convert_to_wav", return_value=str(self.wav_file)):
+                result = transcriber.transcribe_audio(str(self.audio_file))
+
+        self.assertEqual(result, {"text": "hello world"})
+        self.assertFalse(self.wav_file.exists())
+
+    def test_requires_model_path(self):
+        with patch.dict(os.environ, {}, clear=True):
+            transcriber = VoskTranscription()
+            with self.assertRaisesRegex(ValueError, "VOSK_MODEL_PATH"):
+                transcriber.transcribe_audio(str(self.audio_file))
+
+    @staticmethod
+    def _restore_vosk_module(original_vosk):
+        if original_vosk is None:
+            sys.modules.pop("vosk", None)
+        else:
+            sys.modules["vosk"] = original_vosk


### PR DESCRIPTION
## Summary

Adds a local `--api vosk` transcription provider so Sapat can transcribe recordings with an unpacked Vosk model without sending audio to a hosted API.

## Changes

- Adds `VoskTranscription` with env-based `VOSK_MODEL_PATH`, `VOSK_SAMPLE_RATE`, and `VOSK_CHUNK_SIZE` configuration.
- Converts Sapat's intermediate audio into mono WAV before recognition.
- Wires `--api vosk` into the CLI while preserving OpenAI, Groq, and Azure paths.
- Adds an optional `sapat[vosk]` dependency extra and README setup notes.
- Adds mocked unit tests that validate the provider without downloading model weights.

## Validation

- `/tmp/sapat-vosk-venv/bin/python -m unittest discover -s tests -v`
- `/tmp/sapat-vosk-venv/bin/python -m py_compile src/sapat/script.py src/sapat/transcription/vosk.py tests/test_vosk.py`
- `/tmp/sapat-vosk-venv/bin/sapat --help`
- `git diff --check`