### PR TITLE
Add NanoGPT transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and NanoGPT APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and NanoGPT APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
 
 ## Prerequisites
 
-- Python 3.6+
+- Python 3.8+
 - ffmpeg installed and available in the system PATH
 - API access for one or more supported services:
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - NanoGPT API
 
 ## Installation
 
@@ -53,6 +54,13 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # NanoGPT
+   NANOGPT_API_KEY=your_nanogpt_api_key_here
+   NANOGPT_MODEL=Whisper-Large-V3
+   NANOGPT_API_ENDPOINT=https://nano-gpt.com/api/v1/audio/transcriptions
+   NANOGPT_CHAT_MODEL=your_preferred_chat_model_for_correction
+   NANOGPT_CHAT_ENDPOINT=https://nano-gpt.com/api/v1/chat/completions
    ```
 
 ## Building and Installing the Package
@@ -115,12 +123,27 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api nanogpt` for NanoGPT API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
 ```
+
+NanoGPT example:
+
+```
+sapat my_video.mp4 --quality M --language en --api nanogpt
+```
+
+NanoGPT correction example:
+
+```
+sapat my_video.mp4 --quality M --language en --api nanogpt --correct
+```
+
+When using `--correct` with NanoGPT, set `NANOGPT_CHAT_MODEL` so Sapat can call NanoGPT's OpenAI-compatible chat endpoint to clean up the raw transcript.
 
 - If a file is provided, it will process that single file.
 - If a directory is provided, it will process all `.mp4` files in that directory.
@@ -129,7 +152,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and NanoGPT). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "sapat"
 version = "0.1.2"
 description = "Video Transcription Tool using different APIs"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 dependencies = [
     "click>=8.1.8",
     "requests>=2.32.3",

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.nanogpt import NanoGPTTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'nanogpt'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'nanogpt')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "nanogpt":
+        transcriber = NanoGPTTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/nanogpt.py
+++ b/src/sapat/transcription/nanogpt.py
@@ -1,0 +1,159 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class NanoGPTTranscription(TranscriptionBase):
+    """
+    NanoGPT OpenAI-compatible API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        self.api_key = os.getenv("NANOGPT_API_KEY")
+        self.model = os.getenv("NANOGPT_MODEL", "Whisper-Large-V3")
+        self.endpoint = os.getenv(
+            "NANOGPT_API_ENDPOINT",
+            "https://nano-gpt.com/api/v1/audio/transcriptions",
+        )
+        self.chat_model = os.getenv("NANOGPT_CHAT_MODEL")
+        self.chat_endpoint = os.getenv(
+            "NANOGPT_CHAT_ENDPOINT",
+            "https://nano-gpt.com/api/v1/chat/completions",
+        )
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using NanoGPT's OpenAI-compatible STT API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_configuration()
+        self._validate_audio_file(audio_file)
+
+        response_format = kwargs.get("response_format", self.response_format)
+        data = {
+            "model": kwargs.get("model", self.model),
+            "response_format": response_format,
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        language = kwargs.get("language")
+        prompt = kwargs.get("prompt")
+        if language:
+            data["language"] = language
+        if prompt:
+            data["prompt"] = prompt
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                data=data,
+                files={"file": f},
+            )
+
+        if response.status_code == 200:
+            if response_format in ["json", "verbose_json"]:
+                return response.json()
+            return response.text
+
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def generate_corrected_transcript(
+        self, audio_file: str, temperature: float, system_prompt: str
+    ):
+        """
+        Uses NanoGPT's OpenAI-compatible chat endpoint to correct a transcript.
+
+        Parameters:
+        - audio_file (str): Path to the audio file for transcription.
+        - temperature (float): The sampling temperature for the chat API.
+        - system_prompt (str): The system prompt to guide the assistant.
+
+        Returns:
+        - str: The corrected transcription.
+        """
+        self._validate_configuration()
+        if not self.chat_model:
+            raise ValueError(
+                "NANOGPT_CHAT_MODEL must be set to use --correct with NanoGPT."
+            )
+
+        transcription = self.transcribe_audio(audio_file)
+        transcription_text = (
+            transcription.get("text", "") if isinstance(transcription, dict)
+            else transcription
+        )
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.chat_model,
+            "temperature": temperature,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": system_prompt,
+                },
+                {
+                    "role": "user",
+                    "content": transcription_text,
+                },
+            ],
+        }
+
+        response = requests.post(
+            self.chat_endpoint,
+            headers=headers,
+            json=payload,
+        )
+        if response.status_code != 200:
+            raise Exception(f"Transcript correction failed: {response.text}")
+
+        body = response.json()
+        return body["choices"][0]["message"]["content"]
+
+    def _validate_configuration(self):
+        if not self.api_key:
+            raise ValueError("NANOGPT_API_KEY must be set to use the NanoGPT API.")
+        if not self.endpoint:
+            raise ValueError("NANOGPT_API_ENDPOINT must be set to use the NanoGPT API.")
+        if not self.model:
+            raise ValueError("NANOGPT_MODEL must be set to use the NanoGPT API.")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(
+                f"File size exceeds the maximum limit of {self.max_file_size_mb} MB."
+            )
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".ogg", ".m4a", ".aac"]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/tests/test_nanogpt.py
+++ b/tests/test_nanogpt.py
@@ -1,0 +1,172 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+from sapat.transcription.nanogpt import NanoGPTTranscription
+
+
+class NanoGPTTranscriptionTest(unittest.TestCase):
+    def _audio_file(self):
+        handle = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        handle.write(b"audio")
+        handle.close()
+        self.addCleanup(lambda: Path(handle.name).unlink(missing_ok=True))
+        return handle.name
+
+    @patch.dict(
+        os.environ,
+        {
+            "NANOGPT_API_KEY": "test-key",
+            "NANOGPT_MODEL": "Whisper-Large-V3",
+            "NANOGPT_API_ENDPOINT": "https://nano-gpt.com/api/v1/audio/transcriptions",
+        },
+        clear=True,
+    )
+    @patch("sapat.transcription.nanogpt.requests.post")
+    def test_transcribe_audio_posts_openai_compatible_request(self, post):
+        post.return_value = Mock(
+            status_code=200,
+            json=Mock(return_value={"text": "hello"}),
+            text='{"text":"hello"}',
+        )
+        audio_file = self._audio_file()
+
+        result = NanoGPTTranscription(temperature=0.2).transcribe_audio(
+            audio_file,
+            language="en",
+            prompt="Product names: Daytona and Sapat",
+        )
+
+        self.assertEqual(result, {"text": "hello"})
+        _, kwargs = post.call_args
+        self.assertEqual(
+            kwargs["headers"],
+            {"Authorization": "Bearer test-key"},
+        )
+        self.assertEqual(
+            kwargs["data"],
+            {
+                "model": "Whisper-Large-V3",
+                "response_format": "json",
+                "temperature": 0.2,
+                "language": "en",
+                "prompt": "Product names: Daytona and Sapat",
+            },
+        )
+        self.assertIn("file", kwargs["files"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_transcribe_audio_requires_api_key(self):
+        audio_file = self._audio_file()
+
+        with self.assertRaisesRegex(ValueError, "NANOGPT_API_KEY"):
+            NanoGPTTranscription(temperature=0.2).transcribe_audio(audio_file)
+
+    @patch.dict(
+        os.environ,
+        {
+            "NANOGPT_API_KEY": "test-key",
+            "NANOGPT_MODEL": "Whisper-Large-V3",
+            "NANOGPT_API_ENDPOINT": "https://nano-gpt.com/api/v1/audio/transcriptions",
+            "NANOGPT_CHAT_MODEL": "openai/gpt-4o-mini",
+            "NANOGPT_CHAT_ENDPOINT": "https://nano-gpt.com/api/v1/chat/completions",
+        },
+        clear=True,
+    )
+    @patch("sapat.transcription.nanogpt.requests.post")
+    def test_generate_corrected_transcript_posts_chat_request(self, post):
+        transcription_response = Mock(
+            status_code=200,
+            json=Mock(return_value={"text": "raw transkript"}),
+            text='{"text":"raw transkript"}',
+        )
+        correction_response = Mock(
+            status_code=200,
+            json=Mock(
+                return_value={
+                    "choices": [
+                        {"message": {"content": "Raw transcript."}}
+                    ]
+                }
+            ),
+            text='{"choices":[{"message":{"content":"Raw transcript."}}]}',
+        )
+        post.side_effect = [transcription_response, correction_response]
+        audio_file = self._audio_file()
+
+        result = NanoGPTTranscription(temperature=0.2).generate_corrected_transcript(
+            audio_file,
+            0.7,
+            "Fix spelling only.",
+        )
+
+        self.assertEqual(result, "Raw transcript.")
+        _, correction_kwargs = post.call_args_list[1]
+        self.assertEqual(
+            correction_kwargs["headers"],
+            {
+                "Authorization": "Bearer test-key",
+                "Content-Type": "application/json",
+            },
+        )
+        self.assertEqual(
+            correction_kwargs["json"],
+            {
+                "model": "openai/gpt-4o-mini",
+                "temperature": 0.7,
+                "messages": [
+                    {"role": "system", "content": "Fix spelling only."},
+                    {"role": "user", "content": "raw transkript"},
+                ],
+            },
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "NANOGPT_API_KEY": "test-key",
+            "NANOGPT_MODEL": "Whisper-Large-V3",
+            "NANOGPT_API_ENDPOINT": "https://nano-gpt.com/api/v1/audio/transcriptions",
+        },
+        clear=True,
+    )
+    def test_generate_corrected_transcript_requires_chat_model(self):
+        audio_file = self._audio_file()
+
+        with self.assertRaisesRegex(ValueError, "NANOGPT_CHAT_MODEL"):
+            NanoGPTTranscription(temperature=0.2).generate_corrected_transcript(
+                audio_file,
+                0.7,
+                "Fix spelling only.",
+            )
+
+    def test_cli_accepts_nanogpt_provider(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("sample.mp4").write_text("video")
+
+            with patch("sapat.script.NanoGPTTranscription") as transcriber:
+                result = runner.invoke(
+                    main,
+                    [
+                        "sample.mp4",
+                        "--api",
+                        "nanogpt",
+                        "--language",
+                        "en",
+                        "--prompt",
+                        "Use project names",
+                        "--temperature",
+                        "0.1",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0)
+        transcriber.assert_called_once_with(temperature=0.1)
+        transcriber.return_value.process_file.assert_called_once()


### PR DESCRIPTION
## Summary
- add `--api nanogpt` backed by NanoGPT's OpenAI-compatible audio transcription endpoint
- document `NANOGPT_API_KEY`, `NANOGPT_MODEL`, `NANOGPT_API_ENDPOINT`, and NanoGPT chat correction configuration
- implement `--correct` for NanoGPT through NanoGPT's OpenAI-compatible chat endpoint
- add mocked unittest coverage for request wiring, missing configuration, correction, and CLI routing

## Verification
- `UV_PROJECT_ENVIRONMENT=/tmp/sapat-nanogpt-venv uv run python -m unittest tests.test_nanogpt`
- `python -m compileall src tests`
- `git diff --check`

Companion Daytona content PR: https://github.com/daytonaio/content/pull/242