### PR TITLE
Add LocalAI transcription provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *$py.class
 
 # Ignore virtualenv
+.venv/
 venv/
 ENV/
 env.bak/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and LocalAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and LocalAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - LocalAI server with audio-to-text models installed
 
 ## Installation
 
@@ -53,6 +54,12 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # LocalAI
+   LOCALAI_BASE_URL=http://localhost:8080
+   LOCALAI_MODEL=whisper-1
+   # Optional if your LocalAI server requires authentication:
+   LOCALAI_API_KEY=your_localai_token_here
    ```
 
 ## Building and Installing the Package
@@ -115,6 +122,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api localai` for a LocalAI OpenAI-compatible transcription endpoint
 
 Example:
 
@@ -130,6 +138,7 @@ The script will create a `.txt` file with the same name as the input video file,
 ## Note
 
 This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+LocalAI can run locally without cloud API credentials, but you must have a LocalAI server running and a compatible audio-to-text model installed before using `--api localai`.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -1,8 +1,5 @@
 import click
 from pathlib import Path
-from .transcription.groq import GroqCloudTranscription
-from .transcription.azure import AzureTranscription
-from .transcription.openai import OpenAITranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +8,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'localai'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'localai')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -23,11 +20,21 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
 
     # Handle file processing based on API choice
     if api.lower() == "groq":
+        from .transcription.groq import GroqCloudTranscription
+
         transcriber = GroqCloudTranscription(temperature=temperature)
     elif api.lower() == "azure":
+        from .transcription.azure import AzureTranscription
+
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
+        from .transcription.openai import OpenAITranscription
+
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "localai":
+        from .transcription.localai import LocalAITranscription
+
+        transcriber = LocalAITranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/localai.py
+++ b/src/sapat/transcription/localai.py
@@ -1,0 +1,94 @@
+import os
+
+import requests
+
+from .base import TranscriptionBase
+
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    load_dotenv = None
+
+if load_dotenv:
+    load_dotenv(".env")
+
+
+class LocalAITranscription(TranscriptionBase):
+    """
+    LocalAI OpenAI-compatible transcription implementation.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        self.base_url = os.getenv("LOCALAI_BASE_URL")
+        self.endpoint = os.getenv("LOCALAI_API_ENDPOINT") or self._build_endpoint(self.base_url)
+        self.api_key = os.getenv("LOCALAI_API_KEY")
+        self.model = os.getenv("LOCALAI_MODEL", "whisper-1")
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using LocalAI's OpenAI-compatible endpoint.
+        """
+        self._validate_configuration()
+        self._validate_audio_file(audio_file)
+
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        data = {
+            "model": kwargs.get("model", self.model),
+            "response_format": kwargs.get("response_format", self.response_format),
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        if "language" in kwargs:
+            data["language"] = kwargs["language"]
+        if "prompt" in kwargs:
+            data["prompt"] = kwargs["prompt"]
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                data=data,
+                files={"file": f},
+            )
+
+        if response.status_code == 200:
+            if data["response_format"] in ["json", "verbose_json"]:
+                return response.json()
+            return response.text
+
+        raise Exception(f"Transcription failed: {response.text}")
+
+    @staticmethod
+    def _build_endpoint(base_url):
+        if not base_url:
+            return None
+        return f"{base_url.rstrip('/')}/v1/audio/transcriptions"
+
+    def _validate_configuration(self):
+        if not self.endpoint:
+            raise ValueError(
+                "LOCALAI_BASE_URL or LOCALAI_API_ENDPOINT must be set for LocalAI transcription."
+            )
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(
+                f"File size exceeds the maximum limit of {self.max_file_size_mb} MB."
+            )
+
+        valid_extensions = [".mp3", ".wav", ".flac"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_localai.py
+++ b/tests/test_localai.py
@@ -1,0 +1,120 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sapat import script
+
+
+class TestLocalAITranscription(unittest.TestCase):
+    def test_cli_routes_localai_provider(self):
+        calls = []
+
+        class FakeLocalAITranscription:
+            def __init__(self, temperature):
+                self.temperature = temperature
+
+            def process_file(self, input_file, language, prompt, temperature, quality, correct):
+                calls.append(
+                    {
+                        "input_file": input_file,
+                        "language": language,
+                        "prompt": prompt,
+                        "temperature": temperature,
+                        "quality": quality,
+                        "correct": correct,
+                    }
+                )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            video_path = Path(temp_dir) / "demo.mp4"
+            video_path.write_bytes(b"not a real video")
+
+            with patch(
+                "sapat.transcription.localai.LocalAITranscription",
+                FakeLocalAITranscription,
+            ):
+                result = CliRunner().invoke(
+                    script.main,
+                    [
+                        str(video_path),
+                        "--api",
+                        "localai",
+                        "--language",
+                        "en",
+                        "--prompt",
+                        "Product demo vocabulary",
+                        "--temperature",
+                        "0.2",
+                        "--quality",
+                        "H",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["input_file"].name, "demo.mp4")
+        self.assertEqual(calls[0]["language"], "en")
+        self.assertEqual(calls[0]["prompt"], "Product demo vocabulary")
+        self.assertEqual(calls[0]["temperature"], 0.2)
+        self.assertEqual(calls[0]["quality"], "H")
+        self.assertFalse(calls[0]["correct"])
+
+    def test_localai_posts_openai_compatible_transcription_request(self):
+        from sapat.transcription.localai import LocalAITranscription
+
+        captured = {}
+
+        class FakeResponse:
+            status_code = 200
+            text = json.dumps({"text": "hello from localai"})
+
+            def json(self):
+                return {"text": "hello from localai"}
+
+        def fake_post(endpoint, headers, data, files):
+            captured["endpoint"] = endpoint
+            captured["headers"] = headers
+            captured["data"] = data
+            captured["file_name"] = files["file"].name
+            return FakeResponse()
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file:
+            audio_file.write(b"audio")
+            audio_file.flush()
+
+            with patch.dict(
+                os.environ,
+                {
+                    "LOCALAI_BASE_URL": "http://localhost:8080",
+                    "LOCALAI_MODEL": "whisper-large-v3",
+                    "LOCALAI_API_KEY": "test-token",
+                },
+                clear=False,
+            ):
+                transcriber = LocalAITranscription(temperature=0.4)
+                with patch("sapat.transcription.localai.requests.post", fake_post):
+                    result = transcriber.transcribe_audio(
+                        audio_file.name,
+                        language="en",
+                        prompt="meeting vocabulary",
+                        response_format="json",
+                    )
+
+        self.assertEqual(result, {"text": "hello from localai"})
+        self.assertEqual(captured["endpoint"], "http://localhost:8080/v1/audio/transcriptions")
+        self.assertEqual(captured["headers"], {"Authorization": "Bearer test-token"})
+        self.assertEqual(captured["data"]["model"], "whisper-large-v3")
+        self.assertEqual(captured["data"]["response_format"], "json")
+        self.assertEqual(captured["data"]["temperature"], 0.4)
+        self.assertEqual(captured["data"]["language"], "en")
+        self.assertEqual(captured["data"]["prompt"], "meeting vocabulary")
+        self.assertTrue(captured["file_name"].endswith(".mp3"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a LocalAI transcription provider that calls the OpenAI-compatible `/v1/audio/transcriptions` endpoint.
- Exposes `--api localai` and documents `LOCALAI_BASE_URL`, `LOCALAI_MODEL`, and optional `LOCALAI_API_KEY`.
- Keeps optional provider imports lazy so direct `pytest` runs do not require unrelated API SDKs.

## Testing
- `pytest -q`
- `.venv/bin/python -m unittest discover -s tests`
- `.venv/bin/python -m compileall src tests`
- `git diff --check`

This is the companion code change for a Daytona content guide targeting daytonaio/content#13.
