### PR TITLE
Add Picovoice Leopard transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI APIs, and Picovoice Leopard. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI APIs, and Picovoice Leopard
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Picovoice AccessKey for local Leopard transcription
 
 ## Installation
 
@@ -53,6 +54,21 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Picovoice Leopard
+   PICOVOICE_ACCESS_KEY=your_picovoice_access_key_here
+   # Optional:
+   # PICOVOICE_LEOPARD_MODEL_PATH=/absolute/path/to/custom-model.pv
+   # PICOVOICE_LEOPARD_DEVICE=best
+   # PICOVOICE_LEOPARD_ENABLE_PUNCTUATION=true
+   # PICOVOICE_LEOPARD_ENABLE_DIARIZATION=false
+   ```
+
+   Picovoice Leopard support uses the optional `pvleopard` package and requires
+   Python 3.9 or newer:
+
+   ```bash
+   pip install "sapat[leopard]"
    ```
 
 ## Building and Installing the Package
@@ -115,11 +131,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api leopard` for Picovoice Leopard local transcription
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Picovoice Leopard example:
+
+```
+sapat my_video.mp4 --quality M --api leopard
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +152,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Picovoice Leopard). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "groq>=0.13.1"
 ]
 
+[project.optional-dependencies]
+leopard = [
+    "pvleopard>=3.0.1; python_version >= '3.9'"
+]
+
 [project.scripts]
 sapat = "sapat.script:main"
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.leopard import PicovoiceLeopardTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'leopard'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'leopard')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "leopard":
+        transcriber = PicovoiceLeopardTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/leopard.py
+++ b/src/sapat/transcription/leopard.py
@@ -1,0 +1,90 @@
+import os
+
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+load_dotenv(".env")
+
+
+def _bool_from_env(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+class PicovoiceLeopardTranscription(TranscriptionBase):
+    """
+    Picovoice Leopard implementation for local, on-device transcription.
+    """
+
+    def __init__(self, temperature: float, leopard_factory=None):
+        self.temperature = temperature
+        self.access_key = os.getenv("PICOVOICE_ACCESS_KEY")
+        self.model_path = os.getenv("PICOVOICE_LEOPARD_MODEL_PATH") or None
+        self.device = os.getenv("PICOVOICE_LEOPARD_DEVICE") or None
+        self.enable_automatic_punctuation = _bool_from_env(
+            "PICOVOICE_LEOPARD_ENABLE_PUNCTUATION", True
+        )
+        self.enable_diarization = _bool_from_env(
+            "PICOVOICE_LEOPARD_ENABLE_DIARIZATION"
+        )
+        self._leopard_factory = leopard_factory
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Picovoice Leopard.
+
+        Parameters:
+        - audio_file (str): Path to the local audio file.
+        - kwargs: Optional provider overrides for model_path, device,
+          enable_automatic_punctuation, and enable_diarization.
+
+        Returns:
+        - str: The transcript text.
+        """
+        self._validate_audio_file(audio_file)
+        factory = self._get_leopard_factory()
+
+        leopard = factory(
+            access_key=self.access_key,
+            model_path=kwargs.get("model_path", self.model_path),
+            device=kwargs.get("device", self.device),
+            enable_automatic_punctuation=kwargs.get(
+                "enable_automatic_punctuation", self.enable_automatic_punctuation
+            ),
+            enable_diarization=kwargs.get(
+                "enable_diarization", self.enable_diarization
+            ),
+        )
+
+        try:
+            transcript, _words = leopard.process_file(audio_file)
+            return transcript
+        finally:
+            delete = getattr(leopard, "delete", None)
+            if callable(delete):
+                delete()
+
+    def _get_leopard_factory(self):
+        if not self.access_key:
+            raise ValueError("PICOVOICE_ACCESS_KEY is required for --api leopard.")
+
+        if self._leopard_factory is not None:
+            return self._leopard_factory
+
+        try:
+            import pvleopard
+        except ImportError as exc:
+            raise RuntimeError(
+                "Picovoice Leopard support requires pvleopard. "
+                "Install it with `pip install 'sapat[leopard]'`."
+            ) from exc
+
+        return pvleopard.create
+
+    @staticmethod
+    def _validate_audio_file(audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")

--- a/tests/test_leopard.py
+++ b/tests/test_leopard.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from sapat.transcription.leopard import PicovoiceLeopardTranscription
+
+
+class FakeLeopard:
+    def __init__(self):
+        self.deleted = False
+
+    def process_file(self, audio_file):
+        self.audio_file = audio_file
+        return "hello from leopard", []
+
+    def delete(self):
+        self.deleted = True
+
+
+class PicovoiceLeopardTranscriptionTest(unittest.TestCase):
+    def test_transcribes_with_configured_engine_and_deletes_it(self):
+        created = {}
+        fake_engine = FakeLeopard()
+
+        def factory(**kwargs):
+            created.update(kwargs)
+            return fake_engine
+
+        env = {
+            "PICOVOICE_ACCESS_KEY": "access-key",
+            "PICOVOICE_LEOPARD_MODEL_PATH": "/models/leopard.pv",
+            "PICOVOICE_LEOPARD_DEVICE": "best",
+            "PICOVOICE_LEOPARD_ENABLE_PUNCTUATION": "true",
+            "PICOVOICE_LEOPARD_ENABLE_DIARIZATION": "false",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            transcriber = PicovoiceLeopardTranscription(
+                temperature=0.3, leopard_factory=factory
+            )
+            with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+                result = transcriber.transcribe_audio(audio.name)
+
+        self.assertEqual(result, "hello from leopard")
+        self.assertTrue(fake_engine.deleted)
+        self.assertEqual(
+            created,
+            {
+                "access_key": "access-key",
+                "model_path": "/models/leopard.pv",
+                "device": "best",
+                "enable_automatic_punctuation": True,
+                "enable_diarization": False,
+            },
+        )
+
+    def test_missing_access_key_raises_clear_error(self):
+        with patch.dict(os.environ, {}, clear=True):
+            transcriber = PicovoiceLeopardTranscription(
+                temperature=0.3, leopard_factory=lambda **kwargs: FakeLeopard()
+            )
+            with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+                with self.assertRaisesRegex(ValueError, "PICOVOICE_ACCESS_KEY"):
+                    transcriber.transcribe_audio(audio.name)
+
+    def test_missing_audio_file_is_rejected(self):
+        with patch.dict(os.environ, {"PICOVOICE_ACCESS_KEY": "access-key"}, clear=True):
+            transcriber = PicovoiceLeopardTranscription(
+                temperature=0.3, leopard_factory=lambda **kwargs: FakeLeopard()
+            )
+            with self.assertRaisesRegex(ValueError, "does not exist"):
+                transcriber.transcribe_audio("/tmp/does-not-exist.mp3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,63 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from sapat.script import main
+
+
+class ScriptLeopardRoutingTest(unittest.TestCase):
+    def test_leopard_api_routes_to_picovoice_transcriber(self):
+        calls = []
+
+        class FakeTranscriber:
+            def __init__(self, temperature):
+                self.temperature = temperature
+
+            def process_file(self, input_file, language, prompt, temperature, quality, correct):
+                calls.append(
+                    {
+                        "input_file": str(input_file),
+                        "language": language,
+                        "prompt": prompt,
+                        "temperature": temperature,
+                        "quality": quality,
+                        "correct": correct,
+                    }
+                )
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video:
+            with patch("sapat.script.PicovoiceLeopardTranscription", FakeTranscriber):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        video.name,
+                        "--api",
+                        "leopard",
+                        "--language",
+                        "en",
+                        "--prompt",
+                        "product names",
+                        "--temperature",
+                        "0.2",
+                        "--quality",
+                        "H",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["language"], "en")
+        self.assertEqual(calls[0]["prompt"], "product names")
+        self.assertEqual(calls[0]["temperature"], 0.2)
+        self.assertEqual(calls[0]["quality"], "H")
+        self.assertFalse(calls[0]["correct"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Picovoice Leopard provider available through `--api leopard`
- lazy-load the optional `pvleopard` dependency so existing providers do not require it
- document Leopard environment variables and `sapat[leopard]` installation
- add mocked unittest coverage for provider configuration, error handling, cleanup, and CLI routing

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m compileall src tests`
- `.venv/bin/sapat --help`
- `.venv/bin/python -m pip check`
- `git diff --check`

Companion implementation for daytonaio/content#13.