### PR TITLE
Add whisper.cpp transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+WHISPERCPP_BINARY=whisper-cli
+WHISPERCPP_MODEL_PATH=/absolute/path/to/ggml-base.en.bin
+WHISPERCPP_THREADS=4
+WHISPERCPP_EXTRA_ARGS=

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI APIs, and local whisper.cpp. It converts video files to audio, transcribes them, and saves each transcription as a text file.
 
 ## Features
 
-- Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Converts video files to provider-ready audio using ffmpeg
+- Supports transcription using Azure OpenAI, Groq, OpenAI APIs, and local whisper.cpp
 - Supports processing of individual video files or entire directories
-- Cleans up temporary MP3 files after transcription
+- Cleans up temporary audio files after transcription
 - Provides flexibility in selecting the transcription service via configuration
 
 ## Prerequisites
@@ -18,6 +18,9 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+- Optional local whisper.cpp setup:
+  - A compiled `whisper-cli` binary or full binary path
+  - A local `ggml` Whisper model file
 
 ## Installation
 
@@ -53,6 +56,12 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # whisper.cpp
+   WHISPERCPP_BINARY=whisper-cli
+   WHISPERCPP_MODEL_PATH=/absolute/path/to/ggml-base.en.bin
+   WHISPERCPP_THREADS=4
+   WHISPERCPP_EXTRA_ARGS=
    ```
 
 ## Building and Installing the Package
@@ -115,11 +124,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api whispercpp` for local whisper.cpp transcription
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Local whisper.cpp example:
+
+```
+sapat my_video.mp4 --quality M --language en --api whispercpp
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +145,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI) plus a local whisper.cpp option. Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use. For whisper.cpp, ensure `WHISPERCPP_BINARY` and `WHISPERCPP_MODEL_PATH` point to local files available in your workspace.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,15 +3,16 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.whispercpp import WhisperCppTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
 @click.option("--language", "-l", default="en", help="Language of the audio (default: en)")
 @click.option("--prompt", "-p", help="Optional prompt to guide the model")
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
-@click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
+@click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the converted audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'whispercpp'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'whispercpp')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "whispercpp":
+        transcriber = WhisperCppTranscription()
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/whispercpp.py
+++ b/src/sapat/transcription/whispercpp.py
@@ -1,0 +1,159 @@
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import click
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class WhisperCppTranscription(TranscriptionBase):
+    """
+    Local whisper.cpp CLI implementation for offline transcription.
+    """
+
+    def __init__(self):
+        self.binary = os.getenv("WHISPERCPP_BINARY", "whisper-cli")
+        self.model_path = os.getenv("WHISPERCPP_MODEL_PATH")
+        self.threads = os.getenv("WHISPERCPP_THREADS")
+        self.extra_args = shlex.split(os.getenv("WHISPERCPP_EXTRA_ARGS", ""))
+
+    def process_file(self, input_file, language, prompt, temperature, quality, correct):
+        if correct:
+            raise ValueError(
+                "Transcript correction is not available for whisper.cpp. "
+                "Run without --correct, then review the transcript locally."
+            )
+
+        input_path = Path(input_file)
+        txt_file = input_path.with_suffix(".txt")
+
+        click.echo(f"Processing {input_file}")
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            wav_file = Path(tmp.name)
+
+        try:
+            self.convert_to_wav(str(input_path), str(wav_file), quality)
+            click.echo("Conversion to WAV completed")
+
+            transcription_result = self.transcribe_audio(
+                str(wav_file),
+                language=language,
+                prompt=prompt,
+            )
+            click.echo("Transcription completed")
+
+            with open(txt_file, "w", encoding="utf-8") as f:
+                f.write(transcription_result)
+            click.echo(f"Transcription saved to {txt_file}")
+        finally:
+            wav_file.unlink(missing_ok=True)
+
+    @staticmethod
+    def convert_to_wav(input_file: str, output_file: str, quality: str):
+        if quality == "L":
+            sample_rate = "16000"
+        elif quality in ["M", "H"]:
+            sample_rate = "16000"
+        else:
+            raise ValueError("Invalid quality option. Choose from 'L', 'M', 'H'.")
+
+        command = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            input_file,
+            "-vn",
+            "-ar",
+            sample_rate,
+            "-ac",
+            "1",
+            "-c:a",
+            "pcm_s16le",
+            output_file,
+        ]
+        subprocess.run(command, check=True)
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        self._validate_configuration(audio_file)
+
+        command = [
+            self.binary,
+            "-m",
+            self.model_path,
+            "-f",
+            audio_file,
+            "-nt",
+        ]
+
+        language = kwargs.get("language")
+        if language:
+            command.extend(["-l", language])
+
+        prompt = kwargs.get("prompt")
+        if prompt:
+            command.extend(["--prompt", prompt])
+
+        if self.threads:
+            command.extend(["-t", self.threads])
+
+        command.extend(self.extra_args)
+
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return self._clean_output(result.stdout)
+
+    def _validate_configuration(self, audio_file: str):
+        if not self.model_path:
+            raise ValueError(
+                "WHISPERCPP_MODEL_PATH must point to a local ggml model file."
+            )
+
+        if not Path(self.model_path).is_file():
+            raise ValueError(f"Whisper.cpp model not found: {self.model_path}")
+
+        if not Path(audio_file).is_file():
+            raise ValueError(f"Audio file not found: {audio_file}")
+
+        binary_path = Path(self.binary)
+        if not binary_path.is_file() and shutil.which(self.binary) is None:
+            raise ValueError(
+                "whisper.cpp binary not found. Set WHISPERCPP_BINARY to "
+                "whisper-cli or the compiled whisper.cpp binary path."
+            )
+
+    @staticmethod
+    def _clean_output(output: str) -> str:
+        cleaned_lines = []
+        timestamp_pattern = re.compile(
+            r"^\[[0-9:.]+ --> [0-9:.]+\]\s*(?P<text>.*)$"
+        )
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            match = timestamp_pattern.match(stripped)
+            if match:
+                stripped = match.group("text").strip()
+
+            if stripped.startswith(("whisper_", "main:", "system_info:")):
+                continue
+
+            cleaned_lines.append(stripped)
+
+        return "\n".join(cleaned_lines).strip()

--- a/tests/test_whispercpp.py
+++ b/tests/test_whispercpp.py
@@ -1,0 +1,156 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+from sapat.transcription.whispercpp import WhisperCppTranscription
+
+
+class WhisperCppTranscriptionTests(unittest.TestCase):
+    def test_clean_output_removes_timestamps_and_runtime_lines(self):
+        output = """
+whisper_init_from_file: loading model
+[00:00:00.000 --> 00:00:01.000] Hello Daytona.
+main: processing done
+Plain line
+"""
+
+        self.assertEqual(
+            WhisperCppTranscription._clean_output(output),
+            "Hello Daytona.\nPlain line",
+        )
+
+    def test_missing_model_path_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio = Path(tmpdir) / "sample.wav"
+            audio.write_bytes(b"audio")
+
+            with patch.dict(os.environ, {}, clear=True):
+                transcriber = WhisperCppTranscription()
+
+            with self.assertRaisesRegex(ValueError, "WHISPERCPP_MODEL_PATH"):
+                transcriber.transcribe_audio(str(audio))
+
+    def test_transcribe_audio_builds_whispercpp_command(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model = Path(tmpdir) / "ggml-base.en.bin"
+            audio = Path(tmpdir) / "sample.wav"
+            binary = Path(tmpdir) / "whisper-cli"
+            model.write_bytes(b"model")
+            audio.write_bytes(b"audio")
+            binary.write_text("#!/bin/sh\n", encoding="utf-8")
+
+            completed = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="[00:00:00.000 --> 00:00:01.000] Local transcript",
+                stderr="",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "WHISPERCPP_MODEL_PATH": str(model),
+                    "WHISPERCPP_BINARY": str(binary),
+                    "WHISPERCPP_THREADS": "4",
+                    "WHISPERCPP_EXTRA_ARGS": "--no-prints",
+                },
+                clear=True,
+            ):
+                transcriber = WhisperCppTranscription()
+
+            with patch(
+                "sapat.transcription.whispercpp.subprocess.run",
+                return_value=completed,
+            ) as run:
+                transcript = transcriber.transcribe_audio(
+                    str(audio),
+                    language="en",
+                    prompt="Daytona workspace terms",
+                )
+
+            self.assertEqual(transcript, "Local transcript")
+            self.assertEqual(
+                run.call_args.args[0],
+                [
+                    str(binary),
+                    "-m",
+                    str(model),
+                    "-f",
+                    str(audio),
+                    "-nt",
+                    "-l",
+                    "en",
+                    "--prompt",
+                    "Daytona workspace terms",
+                    "-t",
+                    "4",
+                    "--no-prints",
+                ],
+            )
+
+    def test_process_file_converts_to_wav_and_writes_transcript(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model = Path(tmpdir) / "ggml-base.en.bin"
+            binary = Path(tmpdir) / "whisper-cli"
+            video = Path(tmpdir) / "demo.mp4"
+            output = Path(tmpdir) / "demo.txt"
+            model.write_bytes(b"model")
+            binary.write_text("#!/bin/sh\n", encoding="utf-8")
+            video.write_bytes(b"video")
+
+            def fake_run(command, **kwargs):
+                if command[0] == "ffmpeg":
+                    Path(command[-1]).write_bytes(b"wav")
+                    return subprocess.CompletedProcess(command, 0)
+                return subprocess.CompletedProcess(
+                    command,
+                    0,
+                    stdout="Offline transcript",
+                    stderr="",
+                )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "WHISPERCPP_MODEL_PATH": str(model),
+                    "WHISPERCPP_BINARY": str(binary),
+                },
+                clear=True,
+            ):
+                transcriber = WhisperCppTranscription()
+
+            with patch(
+                "sapat.transcription.whispercpp.subprocess.run",
+                side_effect=fake_run,
+            ):
+                transcriber.process_file(video, "en", None, 0.3, "M", False)
+
+            self.assertEqual(output.read_text(encoding="utf-8"), "Offline transcript")
+
+    def test_cli_routes_whispercpp_api(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video = Path(tmpdir) / "demo.mp4"
+            video.write_bytes(b"video")
+
+            with patch.object(
+                WhisperCppTranscription,
+                "process_file",
+                autospec=True,
+            ) as process_file:
+                result = CliRunner().invoke(
+                    main,
+                    [str(video), "--api", "whispercpp", "--language", "en"],
+                )
+
+            self.assertEqual(result.exit_code, 0)
+            process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a local `--api whispercpp` transcription provider backed by the whisper.cpp CLI.
- Convert input video/audio to 16 kHz mono WAV before invoking the local binary, matching whisper.cpp's documented CLI workflow.
- Document `WHISPERCPP_BINARY`, `WHISPERCPP_MODEL_PATH`, `WHISPERCPP_THREADS`, and `WHISPERCPP_EXTRA_ARGS` in the README and `.env.example`.
- Add focused unittest coverage for configuration validation, CLI command construction, output cleanup, file processing, and `sapat --api whispercpp` routing.

## Why
This gives Sapat a no-cloud transcription path for users who want to keep recordings and transcripts inside a local or Daytona workspace. It does not require API keys, does not upload audio to a provider, and keeps the existing OpenAI/Groq/Azure paths unchanged.

This is the companion implementation for the Daytona content bounty submission: https://github.com/daytonaio/content/pull/246

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m compileall src tests`
- `.venv/bin/sapat --help`
- `.venv/bin/python -m pip check`
- `git diff --check`

No model files, private audio, secrets, or generated transcripts are committed.

## Payment
Bounty claim and payout details are handled in the Daytona content PR: https://github.com/daytonaio/content/pull/246
