### PR TITLE
Add AWS Transcribe provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Amazon Transcribe APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Amazon Transcribe APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - AWS account with Amazon Transcribe and S3 permissions
 
 ## Installation
 
@@ -53,6 +54,15 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Amazon Transcribe
+   AWS_TRANSCRIBE_REGION=us-east-1
+   AWS_TRANSCRIBE_S3_BUCKET=your-sapat-input-bucket
+   AWS_TRANSCRIBE_S3_PREFIX=sapat/
+   AWS_TRANSCRIBE_LANGUAGE_CODE=en-US
+   # Optional: store transcript JSON in your own bucket instead of the service bucket
+   AWS_TRANSCRIBE_OUTPUT_BUCKET=your-sapat-output-bucket
+   AWS_TRANSCRIBE_OUTPUT_PREFIX=sapat-transcripts/
    ```
 
 ## Building and Installing the Package
@@ -115,11 +125,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api aws` for Amazon Transcribe
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Amazon Transcribe example:
+
+```
+sapat my_video.mp4 --quality H --language en-US --api aws
 ```
 
 - If a file is provided, it will process that single file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     "requests>=2.32.3",
     "python-dotenv>=1.0.1",
     "openai>=1.58.1",
-    "groq>=0.13.1"
+    "groq>=0.13.1",
+    "boto3>=1.34.0"
 ]
 
 [project.scripts]

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.aws import AWSTranscribeTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'aws'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'aws')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "aws":
+        transcriber = AWSTranscribeTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/aws.py
+++ b/src/sapat/transcription/aws.py
@@ -1,0 +1,162 @@
+import json
+import os
+import re
+import time
+import uuid
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+try:
+    import boto3
+except ImportError:  # pragma: no cover - exercised when users install without boto3
+    boto3 = None
+
+
+load_dotenv(".env")
+
+
+class AWSTranscribeTranscription(TranscriptionBase):
+    """
+    Amazon Transcribe implementation using S3-backed batch jobs.
+    """
+
+    def __init__(self, temperature: float):
+        self.region = os.getenv("AWS_TRANSCRIBE_REGION") or os.getenv("AWS_DEFAULT_REGION") or "us-east-1"
+        self.input_bucket = os.getenv("AWS_TRANSCRIBE_S3_BUCKET")
+        self.input_prefix = os.getenv("AWS_TRANSCRIBE_S3_PREFIX", "sapat/")
+        self.output_bucket = os.getenv("AWS_TRANSCRIBE_OUTPUT_BUCKET")
+        self.output_prefix = os.getenv("AWS_TRANSCRIBE_OUTPUT_PREFIX", "sapat-transcripts/")
+        self.default_language_code = os.getenv("AWS_TRANSCRIBE_LANGUAGE_CODE", "en-US")
+        self.poll_interval = float(os.getenv("AWS_TRANSCRIBE_POLL_INTERVAL", "5"))
+        self.timeout_seconds = int(os.getenv("AWS_TRANSCRIBE_TIMEOUT_SECONDS", "900"))
+        self.delete_uploaded_media = os.getenv("AWS_TRANSCRIBE_DELETE_MEDIA", "true").lower() not in {
+            "0",
+            "false",
+            "no",
+        }
+        self.temperature = temperature
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Uploads audio to S3, starts an Amazon Transcribe job, and returns the transcript text.
+        """
+        self._validate_audio_file(audio_file)
+
+        if not self.input_bucket:
+            raise ValueError("AWS_TRANSCRIBE_S3_BUCKET must be set for AWS transcription.")
+
+        s3 = self._client("s3")
+        transcribe = self._client("transcribe")
+
+        audio_path = Path(audio_file)
+        media_format = self._media_format(audio_path)
+        job_name = self._job_name(audio_path)
+        input_key = self._join_s3_key(self.input_prefix, f"{job_name}.{media_format}")
+
+        output_key = None
+        start_args = {
+            "TranscriptionJobName": job_name,
+            "LanguageCode": self._language_code(kwargs.get("language")),
+            "MediaFormat": media_format,
+            "Media": {"MediaFileUri": f"s3://{self.input_bucket}/{input_key}"},
+        }
+
+        if self.output_bucket:
+            output_key = self._join_s3_key(self.output_prefix, f"{job_name}.json")
+            start_args["OutputBucketName"] = self.output_bucket
+            start_args["OutputKey"] = output_key
+
+        try:
+            s3.upload_file(str(audio_path), self.input_bucket, input_key)
+            transcribe.start_transcription_job(**start_args)
+            job = self._wait_for_job(transcribe, job_name)
+            transcript_json = self._load_transcript_json(s3, job, output_key)
+            return {"text": self._extract_transcript_text(transcript_json), "raw": transcript_json}
+        finally:
+            if self.delete_uploaded_media:
+                try:
+                    s3.delete_object(Bucket=self.input_bucket, Key=input_key)
+                except Exception:
+                    pass
+
+    def _client(self, service_name: str):
+        if boto3 is None:
+            raise ImportError("boto3 is required for AWS transcription. Install Sapat with boto3 support.")
+        return boto3.client(service_name, region_name=self.region)
+
+    def _wait_for_job(self, transcribe, job_name: str):
+        deadline = time.monotonic() + self.timeout_seconds
+        while True:
+            job = transcribe.get_transcription_job(TranscriptionJobName=job_name)["TranscriptionJob"]
+            status = job["TranscriptionJobStatus"]
+            if status == "COMPLETED":
+                return job
+            if status == "FAILED":
+                reason = job.get("FailureReason", "unknown reason")
+                raise RuntimeError(f"Amazon Transcribe job {job_name} failed: {reason}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Amazon Transcribe job {job_name} did not finish in time.")
+            time.sleep(self.poll_interval)
+
+    def _load_transcript_json(self, s3, job, output_key):
+        if self.output_bucket and output_key:
+            obj = s3.get_object(Bucket=self.output_bucket, Key=output_key)
+            return json.loads(obj["Body"].read().decode("utf-8"))
+
+        transcript_uri = job["Transcript"]["TranscriptFileUri"]
+        response = requests.get(transcript_uri, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def _extract_transcript_text(transcript_json):
+        transcripts = transcript_json.get("results", {}).get("transcripts", [])
+        if not transcripts:
+            raise RuntimeError("Amazon Transcribe response did not include transcript text.")
+        return transcripts[0].get("transcript", "")
+
+    def _language_code(self, language):
+        if not language:
+            return self.default_language_code
+        if "-" in language:
+            return language
+        return {
+            "en": "en-US",
+            "es": "es-US",
+            "fr": "fr-FR",
+            "de": "de-DE",
+            "it": "it-IT",
+            "pt": "pt-BR",
+            "ja": "ja-JP",
+            "ko": "ko-KR",
+            "zh": "zh-CN",
+        }.get(language.lower(), self.default_language_code)
+
+    @staticmethod
+    def _join_s3_key(prefix, filename):
+        clean_prefix = (prefix or "").strip("/")
+        return f"{clean_prefix}/{filename}" if clean_prefix else filename
+
+    @staticmethod
+    def _job_name(audio_path: Path):
+        stem = re.sub(r"[^A-Za-z0-9._-]+", "-", audio_path.stem).strip("-") or "audio"
+        return f"sapat-{stem}-{uuid.uuid4().hex[:12]}"
+
+    @staticmethod
+    def _validate_audio_file(audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".mp4", ".ogg", ".webm", ".amr"]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}."
+            )
+
+    @staticmethod
+    def _media_format(audio_path: Path):
+        return audio_path.suffix.lower().lstrip(".")

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,0 +1,136 @@
+import io
+import json
+import os
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from sapat.transcription.aws import AWSTranscribeTranscription
+
+
+class AWSTranscribeTranscriptionTests(unittest.TestCase):
+    def _audio_file(self):
+        tmp = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        tmp.write(b"audio")
+        tmp.close()
+        self.addCleanup(lambda: Path(tmp.name).exists() and Path(tmp.name).unlink())
+        return tmp.name
+
+    def _fake_boto3(self, s3, transcribe):
+        return types.SimpleNamespace(client=Mock(side_effect=[s3, transcribe]))
+
+    @patch.dict(os.environ, {"AWS_TRANSCRIBE_REGION": "us-west-2"}, clear=True)
+    def test_missing_input_bucket_is_rejected(self):
+        transcriber = AWSTranscribeTranscription(temperature=0.0)
+
+        with self.assertRaisesRegex(ValueError, "AWS_TRANSCRIBE_S3_BUCKET"):
+            transcriber.transcribe_audio(self._audio_file())
+
+    @patch("sapat.transcription.aws.time.sleep")
+    @patch("sapat.transcription.aws.requests.get")
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_TRANSCRIBE_S3_BUCKET": "input-bucket",
+            "AWS_TRANSCRIBE_REGION": "us-west-2",
+            "AWS_TRANSCRIBE_POLL_INTERVAL": "0",
+        },
+        clear=True,
+    )
+    def test_transcribes_with_service_managed_transcript_uri(self, mock_get, _mock_sleep):
+        s3 = Mock()
+        transcribe = Mock()
+        transcribe.get_transcription_job.side_effect = [
+            {"TranscriptionJob": {"TranscriptionJobStatus": "IN_PROGRESS"}},
+            {
+                "TranscriptionJob": {
+                    "TranscriptionJobStatus": "COMPLETED",
+                    "Transcript": {"TranscriptFileUri": "https://example.com/result.json"},
+                }
+            },
+        ]
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "results": {"transcripts": [{"transcript": "hello from aws"}]}
+        }
+        mock_get.return_value = mock_response
+
+        with patch("sapat.transcription.aws.boto3", self._fake_boto3(s3, transcribe)):
+            result = AWSTranscribeTranscription(temperature=0.0).transcribe_audio(
+                self._audio_file(), language="en"
+            )
+
+        self.assertEqual(result["text"], "hello from aws")
+        s3.upload_file.assert_called_once()
+        s3.delete_object.assert_called_once()
+        start_args = transcribe.start_transcription_job.call_args.kwargs
+        self.assertEqual(start_args["LanguageCode"], "en-US")
+        self.assertEqual(start_args["MediaFormat"], "mp3")
+        self.assertTrue(start_args["Media"]["MediaFileUri"].startswith("s3://input-bucket/sapat/"))
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch.dict(
+        os.environ,
+        {
+            "AWS_TRANSCRIBE_S3_BUCKET": "input-bucket",
+            "AWS_TRANSCRIBE_OUTPUT_BUCKET": "output-bucket",
+            "AWS_TRANSCRIBE_OUTPUT_PREFIX": "transcripts/",
+            "AWS_TRANSCRIBE_DELETE_MEDIA": "false",
+        },
+        clear=True,
+    )
+    def test_reads_transcript_from_configured_output_bucket(self):
+        s3 = Mock()
+        transcribe = Mock()
+        transcribe.get_transcription_job.return_value = {
+            "TranscriptionJob": {
+                "TranscriptionJobStatus": "COMPLETED",
+                "Transcript": {"TranscriptFileUri": "unused"},
+            }
+        }
+        payload = {"results": {"transcripts": [{"transcript": "from output bucket"}]}}
+        s3.get_object.return_value = {"Body": io.BytesIO(json.dumps(payload).encode("utf-8"))}
+
+        with patch("sapat.transcription.aws.boto3", self._fake_boto3(s3, transcribe)):
+            result = AWSTranscribeTranscription(temperature=0.0).transcribe_audio(self._audio_file())
+
+        self.assertEqual(result["text"], "from output bucket")
+        start_args = transcribe.start_transcription_job.call_args.kwargs
+        self.assertEqual(start_args["OutputBucketName"], "output-bucket")
+        self.assertTrue(start_args["OutputKey"].startswith("transcripts/"))
+        s3.delete_object.assert_not_called()
+
+    @patch.dict(os.environ, {"AWS_TRANSCRIBE_S3_BUCKET": "input-bucket"}, clear=True)
+    def test_failed_job_raises_failure_reason(self):
+        s3 = Mock()
+        transcribe = Mock()
+        transcribe.get_transcription_job.return_value = {
+            "TranscriptionJob": {
+                "TranscriptionJobStatus": "FAILED",
+                "FailureReason": "unsupported media",
+            }
+        }
+
+        with patch("sapat.transcription.aws.boto3", self._fake_boto3(s3, transcribe)):
+            with self.assertRaisesRegex(RuntimeError, "unsupported media"):
+                AWSTranscribeTranscription(temperature=0.0).transcribe_audio(self._audio_file())
+
+    def test_cli_routes_aws_provider(self):
+        from sapat import script
+
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video:
+            with patch.object(script, "AWSTranscribeTranscription") as provider:
+                result = runner.invoke(script.main, [video.name, "--api", "aws"])
+
+        self.assertEqual(result.exit_code, 0)
+        provider.assert_called_once_with(temperature=0.3)
+        provider.return_value.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an `--api aws` Amazon Transcribe provider that uploads converted audio to S3 and starts/polls batch transcription jobs
- support optional transcript output bucket/prefix plus cleanup of uploaded media
- document AWS environment variables and add mocked unit coverage for job success, output-bucket retrieval, failure, config validation, and CLI routing

## Validation
- `.venv/bin/python -m unittest tests.test_aws -v`
- `.venv/bin/python -m compileall src tests`
- `.venv/bin/sapat --help`
- `git diff --check`

No AWS credentials, audio files, or transcript artifacts are committed. This is the companion implementation for the Daytona content guide planned under daytonaio/content#13.