### PR TITLE
Add Baidu transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Baidu Speech Recognition, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Baidu Speech Recognition, Groq, and OpenAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -16,6 +16,7 @@ This tool automates the process of transcribing video files using multiple trans
 - ffmpeg installed and available in the system PATH
 - API access for one or more supported services:
   - Azure OpenAI API
+  - Baidu Speech Recognition API
   - Groq Cloud API
   - OpenAI API
 
@@ -47,6 +48,12 @@ This tool automates the process of transcribing video files using multiple trans
    GROQCLOUD_MODEL=whisper-large-v3-turbo
    GROQCLOUD_API_ENDPOINT=https://api.groq.com/openai/v1/audio/transcriptions
    GROQCLOUD_MODEL_NAME_CHAT=llama3-8b-8192
+
+   # Baidu Speech Recognition
+   BAIDU_API_KEY=your_baidu_api_key_here
+   BAIDU_SECRET_KEY=your_baidu_secret_key_here
+   BAIDU_DEV_PID=1737
+   BAIDU_SAMPLE_RATE=16000
 
    # OpenAI
    OPENAI_API_KEY=your_openai_api_key_here
@@ -113,6 +120,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
 - `--quality`: Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M').
 - `--api`: Specify the API to use for transcription.
    - `--api azure` for Azure OpenAI API
+   - `--api baidu` for Baidu Speech Recognition API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -2,6 +2,7 @@ import click
 from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
+from .transcription.baidu import BaiduTranscription
 from .transcription.openai import OpenAITranscription
 
 @click.command()
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'baidu'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'baidu')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -26,6 +27,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = GroqCloudTranscription(temperature=temperature)
     elif api.lower() == "azure":
         transcriber = AzureTranscription(temperature=temperature)
+    elif api.lower() == "baidu":
+        transcriber = BaiduTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
     else:

--- a/src/sapat/transcription/baidu.py
+++ b/src/sapat/transcription/baidu.py
@@ -1,0 +1,157 @@
+import base64
+import os
+import subprocess
+import uuid
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class BaiduTranscription(TranscriptionBase):
+    """
+    Baidu Speech Recognition API implementation for transcription.
+    """
+
+    TOKEN_ENDPOINT = "https://aip.baidubce.com/oauth/2.0/token"
+    TRANSCRIPTION_ENDPOINT = "https://vop.baidu.com/server_api"
+    LANGUAGE_DEV_PIDS = {
+        "zh": 1537,
+        "zh-cn": 1537,
+        "zh_cn": 1537,
+        "cmn": 1537,
+        "en": 1737,
+        "en-us": 1737,
+        "en_us": 1737,
+    }
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the BaiduTranscription class.
+
+        Parameters:
+        - temperature (float): Kept for compatibility with the shared CLI.
+        - response_format (str): Kept for compatibility with other providers.
+        """
+        self.api_key = os.getenv("BAIDU_API_KEY")
+        self.secret_key = os.getenv("BAIDU_SECRET_KEY")
+        self.cuid = os.getenv("BAIDU_CUID") or f"sapat-{uuid.getnode()}"
+        self.dev_pid = os.getenv("BAIDU_DEV_PID")
+        self.audio_format = os.getenv("BAIDU_AUDIO_FORMAT", "mp3")
+        self.sample_rate = int(os.getenv("BAIDU_SAMPLE_RATE", "16000"))
+        self.endpoint = os.getenv("BAIDU_API_ENDPOINT", self.TRANSCRIPTION_ENDPOINT)
+        self.token_endpoint = os.getenv("BAIDU_TOKEN_ENDPOINT", self.TOKEN_ENDPOINT)
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = int(os.getenv("BAIDU_MAX_FILE_SIZE_MB", "10"))
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Baidu's short speech recognition API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict: The transcription result with a text field.
+        """
+        self._validate_audio_file(audio_file)
+
+        with open(audio_file, "rb") as f:
+            audio_data = f.read()
+
+        payload = {
+            "format": kwargs.get("format", self.audio_format),
+            "rate": int(kwargs.get("rate", self.sample_rate)),
+            "channel": int(kwargs.get("channel", 1)),
+            "cuid": kwargs.get("cuid", self.cuid),
+            "token": self._get_access_token(),
+            "len": len(audio_data),
+            "speech": base64.b64encode(audio_data).decode("utf-8"),
+            "dev_pid": self._resolve_dev_pid(kwargs.get("language")),
+        }
+
+        response = requests.post(
+            self.endpoint,
+            headers={"Content-Type": "application/json"},
+            json=payload,
+            timeout=60,
+        )
+        result = response.json()
+
+        if response.status_code == 200 and result.get("err_no") == 0:
+            transcript = result.get("result", "")
+            if isinstance(transcript, list):
+                transcript = " ".join(transcript)
+            return {"text": transcript}
+
+        error_message = result.get("err_msg", response.text)
+        raise Exception(f"Baidu transcription failed: {error_message}")
+
+    def _get_access_token(self):
+        if not self.api_key or not self.secret_key:
+            raise ValueError("BAIDU_API_KEY and BAIDU_SECRET_KEY must be set.")
+
+        response = requests.get(
+            self.token_endpoint,
+            params={
+                "grant_type": "client_credentials",
+                "client_id": self.api_key,
+                "client_secret": self.secret_key,
+            },
+            timeout=30,
+        )
+        result = response.json()
+
+        if response.status_code == 200 and result.get("access_token"):
+            return result["access_token"]
+
+        error_message = result.get("error_description", response.text)
+        raise Exception(f"Could not fetch Baidu access token: {error_message}")
+
+    def _resolve_dev_pid(self, language):
+        if self.dev_pid:
+            return int(self.dev_pid)
+
+        if not language:
+            return self.LANGUAGE_DEV_PIDS["en"]
+
+        normalized_language = language.lower()
+        return self.LANGUAGE_DEV_PIDS.get(
+            normalized_language,
+            self.LANGUAGE_DEV_PIDS.get(normalized_language.split("-")[0], self.LANGUAGE_DEV_PIDS["en"]),
+        )
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [".mp3", ".wav", ".pcm", ".amr", ".m4a"]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}.")
+
+    @staticmethod
+    def convert_to_mp3(input_file: str, output_file: str, quality: str):
+        command = [
+            "ffmpeg",
+            "-i",
+            input_file,
+            "-vn",
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            "-b:a",
+            "64k",
+            output_file,
+        ]
+        subprocess.run(command, check=True)

--- a/tests/test_baidu.py
+++ b/tests/test_baidu.py
@@ -1,0 +1,74 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sapat.transcription.baidu import BaiduTranscription
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, text=""):
+        self.payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self.payload
+
+
+class BaiduTranscriptionTest(unittest.TestCase):
+    def make_audio_file(self):
+        audio = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        audio.write(b"fake audio bytes")
+        audio.close()
+        self.addCleanup(os.unlink, audio.name)
+        return audio.name
+
+    @patch.dict(os.environ, {"BAIDU_API_KEY": "key", "BAIDU_SECRET_KEY": "secret"}, clear=True)
+    @patch("sapat.transcription.baidu.requests.post")
+    @patch("sapat.transcription.baidu.requests.get")
+    def test_transcribes_with_baidu_payload(self, mock_get, mock_post):
+        mock_get.return_value = FakeResponse({"access_token": "token"})
+        mock_post.return_value = FakeResponse({"err_no": 0, "result": ["hello world"]})
+
+        transcriber = BaiduTranscription(temperature=0.3)
+        result = transcriber.transcribe_audio(self.make_audio_file(), language="en")
+
+        self.assertEqual(result, {"text": "hello world"})
+        mock_get.assert_called_once()
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(payload["token"], "token")
+        self.assertEqual(payload["format"], "mp3")
+        self.assertEqual(payload["rate"], 16000)
+        self.assertEqual(payload["dev_pid"], 1737)
+        self.assertEqual(payload["len"], len(b"fake audio bytes"))
+        self.assertTrue(payload["speech"])
+
+    @patch.dict(os.environ, {"BAIDU_API_KEY": "key", "BAIDU_SECRET_KEY": "secret"}, clear=True)
+    def test_maps_chinese_language_to_mandarin_model(self):
+        transcriber = BaiduTranscription(temperature=0.3)
+
+        self.assertEqual(transcriber._resolve_dev_pid("zh-CN"), 1537)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_requires_credentials(self):
+        transcriber = BaiduTranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "BAIDU_API_KEY"):
+            transcriber._get_access_token()
+
+    @patch.dict(os.environ, {"BAIDU_API_KEY": "key", "BAIDU_SECRET_KEY": "secret"}, clear=True)
+    @patch("sapat.transcription.baidu.requests.post")
+    @patch("sapat.transcription.baidu.requests.get")
+    def test_raises_on_baidu_error(self, mock_get, mock_post):
+        mock_get.return_value = FakeResponse({"access_token": "token"})
+        mock_post.return_value = FakeResponse({"err_no": 3301, "err_msg": "audio quality error"})
+
+        transcriber = BaiduTranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(Exception, "audio quality error"):
+            transcriber.transcribe_audio(self.make_audio_file(), language="en")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_baidu.py
+++ b/tests/test_baidu.py
@@ -1,7 +1,11 @@
 import os
+import sys
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from sapat.transcription.baidu import BaiduTranscription
 


### PR DESCRIPTION
## Summary
- add a Baidu Speech Recognition provider behind `--api baidu`
- use environment-based `BAIDU_API_KEY` / `BAIDU_SECRET_KEY` configuration with no committed secrets
- convert Baidu audio input to mono 16 kHz MP3 and send the short speech recognition request through Baidu's token + `server_api` flow
- add focused unit coverage for token usage, request payload construction, language model routing, missing credentials, and API errors
- document the new environment variables and CLI option

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m compileall src tests`
- `.venv/bin/sapat --help`
- `git diff --check`

No secrets, payout details, or private audio are included.