### PR TITLE
Add Oracle Cloud AI Speech provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI APIs, and Oracle Cloud AI Speech. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI APIs, and Oracle Cloud AI Speech
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Oracle Cloud Infrastructure Object Storage and AI Speech access
 
 ## Installation
 
@@ -53,6 +54,17 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Oracle Cloud AI Speech
+   OCI_CONFIG_FILE=~/.oci/config
+   OCI_PROFILE=DEFAULT
+   OCI_COMPARTMENT_ID=ocid1.compartment.oc1..example
+   OCI_OBJECT_STORAGE_NAMESPACE=your_namespace
+   OCI_SPEECH_INPUT_BUCKET=your_input_bucket
+   OCI_SPEECH_OUTPUT_BUCKET=your_output_bucket
+   OCI_SPEECH_OUTPUT_PREFIX=sapat-transcripts
+   OCI_SPEECH_MODEL_TYPE=ORACLE
+   OCI_SPEECH_LANGUAGE_CODE=en-US
    ```
 
 ## Building and Installing the Package
@@ -115,11 +127,19 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api oracle` for Oracle Cloud AI Speech
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Oracle Cloud AI Speech example:
+
+```
+pip install "sapat[oracle]"
+sapat meeting.mp4 --quality M --language en-US --api oracle
 ```
 
 - If a file is provided, it will process that single file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "groq>=0.13.1"
 ]
 
+[project.optional-dependencies]
+oracle = [
+    "oci>=2.126.0"
+]
+
 [project.scripts]
 sapat = "sapat.script:main"
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.oracle import OracleSpeechTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'oracle'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'oracle')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "oracle":
+        transcriber = OracleSpeechTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/oracle.py
+++ b/src/sapat/transcription/oracle.py
@@ -1,0 +1,210 @@
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+SUPPORTED_MODEL_TYPES = {"ORACLE", "WHISPER_MEDIUM", "WHISPER_LARGE_V2"}
+ORACLE_LANGUAGE_ALIASES = {
+    "en": "en-US",
+    "de": "de-DE",
+    "es": "es-ES",
+    "fr": "fr-FR",
+    "it": "it-IT",
+    "pt": "pt-BR",
+}
+
+
+class OracleSpeechTranscription(TranscriptionBase):
+    """
+    Oracle Cloud AI Speech transcription using Object Storage input/output.
+    """
+
+    def __init__(self, temperature: float):
+        self.temperature = temperature
+        self.config_file = os.getenv("OCI_CONFIG_FILE")
+        self.profile = os.getenv("OCI_PROFILE", "DEFAULT")
+        self.compartment_id = os.getenv("OCI_COMPARTMENT_ID")
+        self.namespace = os.getenv("OCI_OBJECT_STORAGE_NAMESPACE")
+        self.input_bucket = os.getenv("OCI_SPEECH_INPUT_BUCKET")
+        self.output_bucket = os.getenv("OCI_SPEECH_OUTPUT_BUCKET", self.input_bucket or "")
+        self.output_prefix = os.getenv("OCI_SPEECH_OUTPUT_PREFIX", "sapat-transcripts")
+        self.model_type = os.getenv("OCI_SPEECH_MODEL_TYPE", "ORACLE").strip().upper()
+        self.language_code = os.getenv("OCI_SPEECH_LANGUAGE_CODE", "en-US")
+        self.poll_interval = float(os.getenv("OCI_SPEECH_POLL_INTERVAL_SECONDS", "5"))
+        self.wait_seconds = float(os.getenv("OCI_SPEECH_WAIT_SECONDS", "900"))
+        self.cleanup_input = os.getenv("OCI_SPEECH_CLEANUP_INPUT", "true").lower() != "false"
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        audio_path = Path(audio_file)
+        if not audio_path.exists():
+            raise ValueError(f"File {audio_file} does not exist.")
+        self._validate_configuration()
+
+        oci = self._load_oci()
+        config = self._load_config(oci)
+        object_client = oci.object_storage.ObjectStorageClient(config)
+        speech_client = oci.ai_speech.AIServiceSpeechClient(config)
+
+        object_name = self._upload_audio(object_client, audio_path)
+        try:
+            job_id = self._create_job(oci, speech_client, object_name, kwargs)
+            task = self._wait_for_task(speech_client, job_id)
+            return self._read_transcript(object_client, task)
+        finally:
+            if self.cleanup_input:
+                try:
+                    object_client.delete_object(self.namespace, self.input_bucket, object_name)
+                except Exception:
+                    pass
+
+    def _validate_configuration(self):
+        required = {
+            "OCI_COMPARTMENT_ID": self.compartment_id,
+            "OCI_OBJECT_STORAGE_NAMESPACE": self.namespace,
+            "OCI_SPEECH_INPUT_BUCKET": self.input_bucket,
+            "OCI_SPEECH_OUTPUT_BUCKET": self.output_bucket,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise ValueError(f"Missing Oracle Speech configuration: {', '.join(missing)}")
+
+    @staticmethod
+    def _load_oci():
+        try:
+            import oci
+        except ImportError as exc:
+            raise RuntimeError('Oracle Speech support requires installing sapat with "sapat[oracle]".') from exc
+        return oci
+
+    def _load_config(self, oci):
+        if self.config_file:
+            return oci.config.from_file(file_location=self.config_file, profile_name=self.profile)
+        return oci.config.from_file(profile_name=self.profile)
+
+    def _upload_audio(self, object_client, audio_path: Path) -> str:
+        object_name = f"sapat-input/{uuid.uuid4()}-{audio_path.name}"
+        with audio_path.open("rb") as audio:
+            object_client.put_object(self.namespace, self.input_bucket, object_name, audio)
+        return object_name
+
+    def _create_job(self, oci, speech_client, object_name: str, kwargs) -> str:
+        models = oci.ai_speech.models
+        language = self._normalize_language(kwargs.get("language") or self.language_code)
+        details = models.CreateTranscriptionJobDetails(
+            compartment_id=self.compartment_id,
+            display_name=f"sapat-{uuid.uuid4()}",
+            input_location=models.ObjectListInlineInputLocation(
+                object_locations=[
+                    models.ObjectLocation(
+                        namespace_name=self.namespace,
+                        bucket_name=self.input_bucket,
+                        object_names=[object_name],
+                    )
+                ]
+            ),
+            output_location=models.OutputLocation(
+                namespace_name=self.namespace,
+                bucket_name=self.output_bucket,
+                prefix=self.output_prefix,
+            ),
+            model_details=models.TranscriptionModelDetails(
+                model_type=self.model_type,
+                domain="GENERIC",
+                language_code=language,
+            ),
+        )
+        response = speech_client.create_transcription_job(details)
+        job = response.data
+        job_id = getattr(job, "id", None)
+        if not job_id:
+            raise RuntimeError("Oracle Speech did not return a transcription job id.")
+        return job_id
+
+    def _wait_for_task(self, speech_client, job_id: str):
+        deadline = time.time() + self.wait_seconds
+        last_state = "UNKNOWN"
+        while time.time() < deadline:
+            response = speech_client.list_transcription_tasks(job_id)
+            tasks = list(getattr(response.data, "items", None) or getattr(response.data, "data", None) or [])
+            if tasks:
+                task = tasks[0]
+                state = str(getattr(task, "lifecycle_state", "") or "").upper()
+                if state == "SUCCEEDED":
+                    task_id = getattr(task, "id", None)
+                    if not task_id:
+                        raise RuntimeError("Oracle Speech task succeeded without a task id.")
+                    return speech_client.get_transcription_task(job_id, task_id).data
+                if state in {"FAILED", "CANCELED"}:
+                    details = getattr(task, "lifecycle_details", "") or state
+                    raise RuntimeError(f"Oracle Speech task failed: {details}")
+                last_state = state or last_state
+            time.sleep(self.poll_interval)
+        raise TimeoutError(f"Oracle Speech transcription timed out while task was {last_state}.")
+
+    def _normalize_language(self, language: str) -> str:
+        if self.model_type not in SUPPORTED_MODEL_TYPES:
+            supported = ", ".join(sorted(SUPPORTED_MODEL_TYPES))
+            raise ValueError(f"Unsupported OCI_SPEECH_MODEL_TYPE {self.model_type!r}; expected one of {supported}.")
+
+        if not language:
+            return self.language_code
+
+        language = ORACLE_LANGUAGE_ALIASES.get(language.lower(), language)
+        if self.model_type == "ORACLE":
+            if language.lower() == "auto":
+                raise ValueError("Oracle Speech model ORACLE requires an explicit locale such as en-US.")
+            if "-" not in language:
+                raise ValueError(
+                    "Oracle Speech model ORACLE requires a locale code such as en-US. "
+                    "Set OCI_SPEECH_MODEL_TYPE=WHISPER_MEDIUM or WHISPER_LARGE_V2 for auto/short-code use."
+                )
+        return language
+
+    def _read_transcript(self, object_client, task) -> str:
+        output_location = getattr(task, "output_location", None)
+        if not output_location:
+            raise RuntimeError("Oracle Speech task did not include an output location.")
+        object_names = list(getattr(output_location, "object_names", None) or [])
+        if not object_names:
+            raise RuntimeError("Oracle Speech task did not include transcript object names.")
+        response = object_client.get_object(
+            getattr(output_location, "namespace_name", self.namespace),
+            getattr(output_location, "bucket_name", self.output_bucket),
+            object_names[0],
+        )
+        raw = response.data.content.decode("utf-8")
+        return self._extract_text(raw)
+
+    @staticmethod
+    def _extract_text(raw: str) -> str:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return raw.strip()
+
+        for key in ("transcription", "text"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                return value.strip()
+
+        transcriptions = payload.get("transcriptions")
+        if isinstance(transcriptions, list):
+            parts = []
+            for item in transcriptions:
+                if isinstance(item, dict):
+                    value = item.get("transcription") or item.get("text")
+                    if isinstance(value, str):
+                        parts.append(value.strip())
+            if parts:
+                return "\n".join(part for part in parts if part)
+
+        return json.dumps(payload, indent=2)

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,0 +1,119 @@
+import json
+import os
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from sapat.transcription.oracle import OracleSpeechTranscription
+
+
+class OracleSpeechTranscriptionTests(unittest.TestCase):
+    def test_transcribe_audio_uploads_job_polls_and_reads_output(self):
+        audio_file = Path("sample.mp3")
+        audio_file.write_bytes(b"fake mp3")
+        object_client = Mock()
+        speech_client = Mock()
+        speech_client.create_transcription_job.return_value.data = types.SimpleNamespace(id="job1")
+        speech_client.list_transcription_tasks.return_value.data = types.SimpleNamespace(
+            items=[
+                types.SimpleNamespace(
+                    id="task1",
+                    lifecycle_state="SUCCEEDED",
+                )
+            ]
+        )
+        speech_client.get_transcription_task.return_value.data = types.SimpleNamespace(
+            output_location=types.SimpleNamespace(
+                namespace_name="ns",
+                bucket_name="out",
+                object_names=["sapat-transcripts/job1/sample.json"],
+            ),
+        )
+        object_client.get_object.return_value.data.content = json.dumps(
+            {"transcriptions": [{"transcription": "oracle transcript"}]}
+        ).encode("utf-8")
+        oci = self._fake_oci(object_client, speech_client)
+
+        env = {
+            "OCI_COMPARTMENT_ID": "ocid1.compartment.oc1..example",
+            "OCI_OBJECT_STORAGE_NAMESPACE": "ns",
+            "OCI_SPEECH_INPUT_BUCKET": "in",
+            "OCI_SPEECH_OUTPUT_BUCKET": "out",
+            "OCI_SPEECH_POLL_INTERVAL_SECONDS": "0",
+        }
+
+        try:
+            with patch.dict(os.environ, env, clear=False), patch.object(
+                OracleSpeechTranscription, "_load_oci", return_value=oci
+            ):
+                transcript = OracleSpeechTranscription(temperature=0.3).transcribe_audio(
+                    str(audio_file),
+                    language="en",
+                )
+        finally:
+            if audio_file.exists():
+                audio_file.unlink()
+
+        self.assertEqual(transcript, "oracle transcript")
+        object_client.put_object.assert_called_once()
+        speech_client.create_transcription_job.assert_called_once()
+        speech_client.list_transcription_tasks.assert_called_once_with("job1")
+        speech_client.get_transcription_task.assert_called_once_with("job1", "task1")
+        object_client.get_object.assert_called_once_with("ns", "out", "sapat-transcripts/job1/sample.json")
+
+    def test_transcribe_audio_requires_oracle_settings(self):
+        audio_file = Path("sample.mp3")
+        audio_file.write_bytes(b"fake mp3")
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(ValueError, "OCI_COMPARTMENT_ID"):
+                    OracleSpeechTranscription(temperature=0.3).transcribe_audio(str(audio_file))
+        finally:
+            if audio_file.exists():
+                audio_file.unlink()
+
+    def test_oracle_model_requires_locale_language(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OCI_COMPARTMENT_ID": "ocid1.compartment.oc1..example",
+                "OCI_OBJECT_STORAGE_NAMESPACE": "ns",
+                "OCI_SPEECH_INPUT_BUCKET": "in",
+                "OCI_SPEECH_OUTPUT_BUCKET": "out",
+            },
+            clear=True,
+        ):
+            transcriber = OracleSpeechTranscription(temperature=0.3)
+
+        self.assertEqual(transcriber._normalize_language("es"), "es-ES")
+        with self.assertRaisesRegex(ValueError, "requires an explicit locale"):
+            transcriber._normalize_language("auto")
+
+    def _fake_oci(self, object_client, speech_client):
+        models = types.SimpleNamespace(
+            CreateTranscriptionJobDetails=self._record_factory("CreateTranscriptionJobDetails"),
+            ObjectListInlineInputLocation=self._record_factory("ObjectListInlineInputLocation"),
+            ObjectLocation=self._record_factory("ObjectLocation"),
+            OutputLocation=self._record_factory("OutputLocation"),
+            TranscriptionModelDetails=self._record_factory("TranscriptionModelDetails"),
+        )
+        return types.SimpleNamespace(
+            config=types.SimpleNamespace(from_file=Mock(return_value={"region": "us-ashburn-1"})),
+            object_storage=types.SimpleNamespace(ObjectStorageClient=Mock(return_value=object_client)),
+            ai_speech=types.SimpleNamespace(
+                AIServiceSpeechClient=Mock(return_value=speech_client),
+                models=models,
+            ),
+        )
+
+    @staticmethod
+    def _record_factory(name):
+        def factory(**kwargs):
+            return types.SimpleNamespace(_model_name=name, **kwargs)
+
+        return factory
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,24 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+
+
+class ScriptTests(unittest.TestCase):
+    def test_oracle_api_routes_to_oracle_transcriber(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("input.mp4").write_bytes(b"fake video")
+            with patch("sapat.script.OracleSpeechTranscription") as transcriber_cls:
+                result = runner.invoke(main, ["input.mp4", "--api", "oracle"])
+
+        self.assertEqual(result.exit_code, 0)
+        transcriber_cls.assert_called_once()
+        transcriber_cls.return_value.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an Oracle Cloud AI Speech transcription provider behind `--api oracle`.

The provider:
- uploads Sapat's generated MP3 to OCI Object Storage
- creates an Oracle Cloud AI Speech transcription job
- polls the transcription task and fetches the full task before reading output
- reads transcript JSON from the configured output bucket
- supports Oracle locale normalization and explicit configuration errors
- keeps OCI support as an optional `sapat[oracle]` dependency

## Validation

- `python -m unittest discover -s tests -v`
- `python -m compileall src tests`
- `sapat --help`
- `git diff --check`