### PR TITLE
Add DeepInfra transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and DeepInfra APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and DeepInfra APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - DeepInfra API
 
 ## Installation
 
@@ -53,6 +54,15 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # DeepInfra
+   DEEPINFRA_TOKEN=your_deepinfra_token_here
+   DEEPINFRA_MODEL=openai/whisper-large
+   # Optional full speech endpoint override:
+   # DEEPINFRA_API_ENDPOINT=https://api.deepinfra.com/v1/inference/openai/whisper-large
+   # Optional chat model for --correct:
+   DEEPINFRA_MODEL_NAME_CHAT=deepseek-ai/DeepSeek-V3
+   DEEPINFRA_OPENAI_ENDPOINT=https://api.deepinfra.com/v1/openai
    ```
 
 ## Building and Installing the Package
@@ -115,6 +125,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api deepinfra` for DeepInfra speech recognition
 
 Example:
 
@@ -129,7 +140,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and DeepInfra). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.deepinfra import DeepInfraTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'deepinfra'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'deepinfra')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "deepinfra":
+        transcriber = DeepInfraTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/deepinfra.py
+++ b/src/sapat/transcription/deepinfra.py
@@ -1,0 +1,140 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+from openai import OpenAI
+
+from .base import TranscriptionBase
+
+load_dotenv(".env")
+
+
+class DeepInfraTranscription(TranscriptionBase):
+    """
+    DeepInfra native speech-recognition implementation.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        self.api_key = os.getenv("DEEPINFRA_TOKEN")
+        self.model = os.getenv("DEEPINFRA_MODEL", "openai/whisper-large")
+        self.endpoint = os.getenv("DEEPINFRA_API_ENDPOINT")
+        self.model_name_chat = os.getenv("DEEPINFRA_MODEL_NAME_CHAT")
+        self.openai_endpoint = os.getenv(
+            "DEEPINFRA_OPENAI_ENDPOINT",
+            "https://api.deepinfra.com/v1/openai",
+        )
+        self.temperature = temperature
+        self.response_format = response_format
+        self.timeout = float(os.getenv("DEEPINFRA_TIMEOUT", "60"))
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using DeepInfra's native speech API.
+        """
+        self._validate_audio_file(audio_file)
+        self._validate_config()
+
+        data = self._build_request_data(kwargs)
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+        with open(audio_file, "rb") as f:
+            files = {"audio": f}
+            response = requests.post(
+                self._transcription_url(kwargs.get("model")),
+                headers=headers,
+                data=data,
+                files=files,
+                timeout=kwargs.get("timeout", self.timeout),
+            )
+
+        if response.status_code != 200:
+            raise Exception(f"DeepInfra transcription failed: {response.text}")
+
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
+
+    def generate_corrected_transcript(
+        self,
+        audio_file: str,
+        temperature: float,
+        system_prompt: str,
+    ):
+        """
+        Uses DeepInfra's OpenAI-compatible chat API to correct transcript text.
+        """
+        self._validate_config()
+        if not self.model_name_chat:
+            raise ValueError(
+                "DEEPINFRA_MODEL_NAME_CHAT is required when using --correct "
+                "with the DeepInfra provider."
+            )
+
+        transcription = self.transcribe_audio(audio_file)
+        transcription_text = (
+            transcription.get("text", "")
+            if isinstance(transcription, dict)
+            else transcription
+        )
+
+        client = OpenAI(api_key=self.api_key, base_url=self.openai_endpoint)
+        response = client.chat.completions.create(
+            model=self.model_name_chat,
+            temperature=temperature,
+            messages=[
+                {
+                    "role": "system",
+                    "content": system_prompt,
+                },
+                {
+                    "role": "user",
+                    "content": transcription_text,
+                },
+            ],
+        )
+        return response.choices[0].message.content
+
+    def _transcription_url(self, model_override=None):
+        if self.endpoint:
+            return self.endpoint
+
+        model = model_override or self.model
+        return f"https://api.deepinfra.com/v1/inference/{model}"
+
+    def _build_request_data(self, kwargs):
+        data = {}
+        for key in ("language", "prompt", "task"):
+            value = kwargs.get(key)
+            if value:
+                data[key] = value
+
+        temperature = kwargs.get("temperature", self.temperature)
+        if temperature is not None:
+            data["temperature"] = temperature
+
+        return data
+
+    def _validate_config(self):
+        if not self.api_key:
+            raise ValueError("DEEPINFRA_TOKEN is required for DeepInfra transcription.")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(
+                f"File size exceeds the maximum limit of {self.max_file_size_mb} MB."
+            )
+
+        valid_extensions = [".mp3", ".wav"]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )

--- a/tests/test_deepinfra.py
+++ b/tests/test_deepinfra.py
@@ -1,0 +1,134 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+from sapat.transcription.deepinfra import DeepInfraTranscription
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self.payload = payload
+        self.text = text
+
+    def json(self):
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+class DeepInfraTranscriptionTest(unittest.TestCase):
+    def setUp(self):
+        self.env = patch.dict(os.environ, {}, clear=True)
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+
+    def test_requires_token(self):
+        audio_file = self._audio_file(".mp3")
+        transcriber = DeepInfraTranscription(temperature=0.3)
+
+        with self.assertRaisesRegex(ValueError, "DEEPINFRA_TOKEN"):
+            transcriber.transcribe_audio(audio_file)
+
+    @patch("sapat.transcription.deepinfra.requests.post")
+    def test_posts_audio_to_default_model_endpoint(self, mock_post):
+        os.environ["DEEPINFRA_TOKEN"] = "test-token"
+        os.environ["DEEPINFRA_MODEL"] = "openai/whisper-small"
+        mock_post.return_value = FakeResponse(payload={"text": "hello world"})
+        audio_file = self._audio_file(".mp3")
+
+        result = DeepInfraTranscription(temperature=0.2).transcribe_audio(
+            audio_file,
+            language="en",
+            prompt="Product names: Sapat",
+        )
+
+        self.assertEqual(result["text"], "hello world")
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        self.assertEqual(
+            kwargs["headers"]["Authorization"],
+            "Bearer test-token",
+        )
+        self.assertEqual(
+            mock_post.call_args.args[0],
+            "https://api.deepinfra.com/v1/inference/openai/whisper-small",
+        )
+        self.assertEqual(kwargs["data"]["language"], "en")
+        self.assertEqual(kwargs["data"]["prompt"], "Product names: Sapat")
+        self.assertEqual(kwargs["data"]["temperature"], 0.2)
+        self.assertIn("audio", kwargs["files"])
+
+    @patch("sapat.transcription.deepinfra.requests.post")
+    def test_allows_endpoint_override(self, mock_post):
+        os.environ["DEEPINFRA_TOKEN"] = "test-token"
+        os.environ["DEEPINFRA_API_ENDPOINT"] = (
+            "https://proxy.example/v1/inference/openai/whisper-large"
+        )
+        mock_post.return_value = FakeResponse(payload={"text": "via proxy"})
+        audio_file = self._audio_file(".wav")
+
+        result = DeepInfraTranscription(temperature=0.1).transcribe_audio(audio_file)
+
+        self.assertEqual(result["text"], "via proxy")
+        self.assertEqual(
+            mock_post.call_args.args[0],
+            "https://proxy.example/v1/inference/openai/whisper-large",
+        )
+
+    @patch("sapat.transcription.deepinfra.requests.post")
+    def test_raises_api_errors(self, mock_post):
+        os.environ["DEEPINFRA_TOKEN"] = "test-token"
+        mock_post.return_value = FakeResponse(status_code=401, text="unauthorized")
+        audio_file = self._audio_file(".mp3")
+
+        with self.assertRaisesRegex(Exception, "DeepInfra transcription failed"):
+            DeepInfraTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+    def test_rejects_unsupported_audio_extension(self):
+        os.environ["DEEPINFRA_TOKEN"] = "test-token"
+        audio_file = self._audio_file(".flac")
+
+        with self.assertRaisesRegex(ValueError, "Unsupported audio file format"):
+            DeepInfraTranscription(temperature=0.3).transcribe_audio(audio_file)
+
+    @patch("sapat.script.DeepInfraTranscription")
+    def test_cli_routes_deepinfra_choice(self, mock_transcription):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_file = Path(tmpdir) / "demo.mp4"
+            video_file.write_bytes(b"fake video")
+            transcriber = MagicMock()
+            mock_transcription.return_value = transcriber
+
+            result = CliRunner().invoke(
+                main,
+                [str(video_file), "--api", "deepinfra", "--temperature", "0.4"],
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        mock_transcription.assert_called_once_with(temperature=0.4)
+        transcriber.process_file.assert_called_once()
+
+    def _audio_file(self, suffix):
+        handle = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        handle.write(b"audio")
+        handle.close()
+        self.addCleanup(self._remove_file, handle.name)
+        return handle.name
+
+    @staticmethod
+    def _remove_file(file_name):
+        path = Path(file_name)
+        if path.exists():
+            path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `--api deepinfra` backed by DeepInfra native speech recognition
- document DeepInfra environment variables and optional chat correction config
- add mocked unit coverage for config validation, request construction, endpoint override, API errors, and CLI routing

## Verification
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m compileall src tests`
- `.venv/bin/sapat --help` includes `deepinfra`
- `git diff --check`

Companion content PR for the Daytona guide will link back here.