### PR TITLE
Add STT.ai transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and STT.ai APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and STT.ai APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - STT.ai API
 
 ## Installation
 
@@ -53,6 +54,14 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # STT.ai
+   STTAI_API_KEY=your_sttai_api_key_here
+   STTAI_MODEL=large-v3-turbo
+   STTAI_API_ENDPOINT=https://api.stt.ai/v1/transcribe
+   STTAI_DIARIZE=true
+   STTAI_SPEAKERS=0
+   STTAI_RESPONSE_FORMAT=json
    ```
 
 ## Building and Installing the Package
@@ -115,11 +124,18 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api sttai` for STT.ai API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+STT.ai example:
+
+```
+sapat my_video.mp4 --quality H --language auto --api sttai
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +145,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and STT.ai). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.sttai import STTAITranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'sttai'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'sttai')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "sttai":
+        transcriber = STTAITranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/sttai.py
+++ b/src/sapat/transcription/sttai.py
@@ -1,0 +1,96 @@
+import mimetypes
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class STTAITranscription(TranscriptionBase):
+    """
+    STT.ai API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the STTAITranscription class.
+
+        Parameters:
+        - temperature (float): Accepted for CLI compatibility. STT.ai does not use it.
+        - response_format (str): Default response format for transcription.
+        """
+        self.api_key = os.getenv("STTAI_API_KEY")
+        self.endpoint = os.getenv("STTAI_API_ENDPOINT", "https://api.stt.ai/v1/transcribe")
+        self.model = os.getenv("STTAI_MODEL", "large-v3-turbo")
+        self.diarize = os.getenv("STTAI_DIARIZE", "true")
+        self.speakers = os.getenv("STTAI_SPEAKERS", "0")
+        self.temperature = temperature
+        self.response_format = os.getenv("STTAI_RESPONSE_FORMAT", response_format)
+        self.max_file_size_mb = float(os.getenv("STTAI_MAX_FILE_SIZE_MB", "500"))
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using the STT.ai transcription API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_audio_file(audio_file)
+
+        response_format = kwargs.get("response_format", self.response_format)
+        data = {
+            "model": kwargs.get("model", self.model),
+            "language": kwargs.get("language", "auto"),
+            "diarize": kwargs.get("diarize", self.diarize),
+            "speakers": str(kwargs.get("speakers", self.speakers)),
+            "response_format": response_format,
+        }
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        mime_type = mimetypes.guess_type(audio_file)[0] or "audio/mpeg"
+        with open(audio_file, "rb") as f:
+            files = {"file": (os.path.basename(audio_file), f, mime_type)}
+            response = requests.post(self.endpoint, headers=headers, data=data, files=files)
+
+        if response.status_code == 200:
+            if response_format == "json":
+                return response.json()
+            return response.text
+
+        raise Exception(f"STT.ai transcription failed: {response.text}")
+
+    def _validate_audio_file(self, audio_file: str):
+        """
+        Validates the audio file for size and format.
+        """
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [
+            ".mp3",
+            ".wav",
+            ".flac",
+            ".ogg",
+            ".m4a",
+            ".aac",
+            ".opus",
+            ".mp4",
+            ".webm",
+            ".mov",
+        ]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}.")

--- a/tests/test_sttai.py
+++ b/tests/test_sttai.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.sttai import STTAITranscription
+
+
+class STTAITranscriptionTests(unittest.TestCase):
+    def setUp(self):
+        self.env = {
+            "STTAI_API_KEY": "test-key",
+            "STTAI_API_ENDPOINT": "https://api.stt.ai/v1/transcribe",
+            "STTAI_MODEL": "small",
+            "STTAI_DIARIZE": "false",
+            "STTAI_SPEAKERS": "1",
+        }
+
+    def test_transcribe_audio_posts_file_and_options(self):
+        response = Mock(status_code=200)
+        response.json.return_value = {"text": "hello world"}
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file, patch.dict(os.environ, self.env, clear=False), patch(
+            "sapat.transcription.sttai.requests.post", return_value=response
+        ) as post:
+            audio_file.write(b"fake audio")
+            audio_file.flush()
+
+            result = STTAITranscription(temperature=0.3).transcribe_audio(audio_file.name, language="es")
+
+        self.assertEqual(result, {"text": "hello world"})
+        args, kwargs = post.call_args
+        self.assertEqual(args[0], "https://api.stt.ai/v1/transcribe")
+        self.assertEqual(kwargs["headers"], {"Authorization": "Bearer test-key"})
+        self.assertEqual(kwargs["data"]["model"], "small")
+        self.assertEqual(kwargs["data"]["language"], "es")
+        self.assertEqual(kwargs["data"]["diarize"], "false")
+        self.assertEqual(kwargs["data"]["speakers"], "1")
+        self.assertEqual(kwargs["data"]["response_format"], "json")
+        self.assertEqual(kwargs["files"]["file"][0], os.path.basename(audio_file.name))
+
+    def test_transcribe_audio_allows_anonymous_requests(self):
+        response = Mock(status_code=200, text="plain transcript")
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file, patch.dict(os.environ, {"STTAI_API_KEY": ""}, clear=False), patch(
+            "sapat.transcription.sttai.requests.post", return_value=response
+        ) as post:
+            audio_file.write(b"fake audio")
+            audio_file.flush()
+
+            result = STTAITranscription(temperature=0.3, response_format="txt").transcribe_audio(audio_file.name)
+
+        self.assertEqual(result, "plain transcript")
+        self.assertEqual(post.call_args.kwargs["headers"], {})
+
+    def test_transcribe_audio_rejects_missing_file(self):
+        with self.assertRaises(ValueError):
+            STTAITranscription(temperature=0.3).transcribe_audio("/tmp/not-here.mp3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an STT.ai transcription provider exposed as `--api sttai`
- support endpoint/model/diarization/speaker/response-format settings through `STTAI_*` environment variables
- document STT.ai configuration and add mocked unit coverage for request construction, anonymous mode, and missing-file validation

## Validation
- `/tmp/sapat-venv/bin/python -m unittest discover -s tests -v`
- `/tmp/sapat-venv/bin/python -m compileall src tests`
- `/tmp/sapat-venv/bin/sapat --help`
- `git diff --check`

Related Daytona bounty issue: daytonaio/content#13