### PR TITLE
Add Symbl.ai transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,13 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+# Symbl.ai
+# Use an existing access token, or set SYMBL_APP_ID and SYMBL_APP_SECRET so Sapat
+# can generate one through Symbl's OAuth endpoint.
+SYMBL_ACCESS_TOKEN=your_symbl_access_token_here
+SYMBL_APP_ID=your_symbl_app_id_here
+SYMBL_APP_SECRET=your_symbl_app_secret_here
+SYMBL_API_BASE_URL=https://api.symbl.ai/v1
+SYMBL_JOB_POLL_INTERVAL_SECONDS=5
+SYMBL_JOB_TIMEOUT_SECONDS=600

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Ignore virtualenv
 venv/
+.venv/
 ENV/
 env.bak/
 env/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Symbl.ai APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Symbl.ai APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Symbl.ai API
 
 ## Installation
 
@@ -53,6 +54,15 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Symbl.ai
+   # Use either SYMBL_ACCESS_TOKEN or both SYMBL_APP_ID and SYMBL_APP_SECRET.
+   SYMBL_ACCESS_TOKEN=your_symbl_access_token_here
+   SYMBL_APP_ID=your_symbl_app_id_here
+   SYMBL_APP_SECRET=your_symbl_app_secret_here
+   SYMBL_API_BASE_URL=https://api.symbl.ai/v1
+   SYMBL_JOB_POLL_INTERVAL_SECONDS=5
+   SYMBL_JOB_TIMEOUT_SECONDS=600
    ```
 
 ## Building and Installing the Package
@@ -115,6 +125,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api symbl` for Symbl.ai Async Audio API
 
 Example:
 
@@ -129,7 +140,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Symbl.ai). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.symbl import SymblTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'symbl'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'symbl')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "symbl":
+        transcriber = SymblTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/symbl.py
+++ b/src/sapat/transcription/symbl.py
@@ -1,0 +1,185 @@
+import mimetypes
+import os
+import time
+from typing import Dict, Optional
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class SymblTranscription(TranscriptionBase):
+    """
+    Symbl.ai Async Audio API implementation for transcription.
+    """
+
+    DEFAULT_BASE_URL = "https://api.symbl.ai/v1"
+    TOKEN_URL = "https://api.symbl.ai/oauth2/token:generate"
+    LANGUAGE_CODES = {
+        "ar": "ar-SA",
+        "de": "de-DE",
+        "en": "en-US",
+        "es": "es-ES",
+        "fa": "fa-IR",
+        "fr": "fr-FR",
+        "hi": "hi-IN",
+        "it": "it-IT",
+        "ja": "ja-JP",
+        "nl": "nl-NL",
+        "pt": "pt-BR",
+        "ru": "ru-RU",
+    }
+
+    def __init__(
+        self,
+        temperature: float,
+        base_url: Optional[str] = None,
+        poll_interval_seconds: Optional[float] = None,
+        timeout_seconds: Optional[float] = None,
+    ):
+        self.temperature = temperature
+        self.base_url = (base_url or os.getenv("SYMBL_API_BASE_URL") or self.DEFAULT_BASE_URL).rstrip("/")
+        self.access_token = os.getenv("SYMBL_ACCESS_TOKEN")
+        self.app_id = os.getenv("SYMBL_APP_ID")
+        self.app_secret = os.getenv("SYMBL_APP_SECRET")
+        self.poll_interval_seconds = self._float_env(
+            "SYMBL_JOB_POLL_INTERVAL_SECONDS",
+            poll_interval_seconds,
+            5.0,
+        )
+        self.timeout_seconds = self._float_env("SYMBL_JOB_TIMEOUT_SECONDS", timeout_seconds, 600.0)
+
+    @staticmethod
+    def _float_env(name: str, value: Optional[float], default: float) -> float:
+        if value is not None:
+            return float(value)
+        env_value = os.getenv(name)
+        return float(env_value) if env_value else default
+
+    def _get_access_token(self) -> str:
+        if self.access_token:
+            return self.access_token
+
+        if not self.app_id or not self.app_secret:
+            raise ValueError(
+                "Set SYMBL_ACCESS_TOKEN or both SYMBL_APP_ID and SYMBL_APP_SECRET "
+                "before using --api symbl."
+            )
+
+        response = requests.post(
+            self.TOKEN_URL,
+            json={
+                "type": "application",
+                "appId": self.app_id,
+                "appSecret": self.app_secret,
+            },
+            timeout=30,
+        )
+        if response.status_code not in (200, 201):
+            raise Exception(f"Symbl token generation failed: {response.text}")
+
+        token = response.json().get("accessToken")
+        if not token:
+            raise Exception("Symbl token generation response did not include accessToken.")
+        self.access_token = token
+        return token
+
+    def _headers(self, content_type: Optional[str] = None) -> Dict[str, str]:
+        headers = {"Authorization": f"Bearer {self._get_access_token()}"}
+        if content_type:
+            headers["Content-Type"] = content_type
+        return headers
+
+    def _language_code(self, language: Optional[str]) -> str:
+        if not language:
+            return "en-US"
+
+        normalized = language.strip()
+        if "-" in normalized:
+            return normalized
+        return self.LANGUAGE_CODES.get(normalized.lower(), normalized)
+
+    def _content_type(self, audio_file: str) -> str:
+        guessed, _ = mimetypes.guess_type(audio_file)
+        if guessed:
+            return guessed
+
+        if audio_file.endswith(".mp3"):
+            return "audio/mpeg"
+        if audio_file.endswith(".wav"):
+            return "audio/wav"
+        return "application/octet-stream"
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file with Symbl.ai's async audio workflow.
+
+        Symbl returns a job ID and conversation ID. This method waits for the
+        job to complete, then reads the conversation messages as transcript
+        text so Sapat's existing file-writing path can stay unchanged.
+        """
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        process_result = self._submit_audio(audio_file, language=kwargs.get("language"))
+        job_id = process_result.get("jobId")
+        conversation_id = process_result.get("conversationId")
+        if not job_id or not conversation_id:
+            raise Exception(f"Symbl process response missing jobId or conversationId: {process_result}")
+
+        self._wait_for_job(job_id)
+        return {"text": self._get_transcript(conversation_id)}
+
+    def _submit_audio(self, audio_file: str, language: Optional[str]) -> dict:
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                f"{self.base_url}/process/audio",
+                headers=self._headers(self._content_type(audio_file)),
+                params={"languageCode": self._language_code(language)},
+                data=f,
+                timeout=120,
+            )
+
+        if response.status_code not in (200, 201):
+            raise Exception(f"Symbl audio processing failed: {response.text}")
+        return response.json()
+
+    def _wait_for_job(self, job_id: str) -> dict:
+        deadline = time.monotonic() + self.timeout_seconds
+        last_status = None
+
+        while time.monotonic() < deadline:
+            response = requests.get(
+                f"{self.base_url}/job/{job_id}",
+                headers=self._headers(),
+                timeout=30,
+            )
+            if response.status_code != 200:
+                raise Exception(f"Symbl job status failed: {response.text}")
+
+            payload = response.json()
+            last_status = payload.get("status")
+            if last_status == "completed":
+                return payload
+            if last_status in {"failed", "error"}:
+                raise Exception(f"Symbl job failed: {payload}")
+
+            time.sleep(self.poll_interval_seconds)
+
+        raise TimeoutError(f"Timed out waiting for Symbl job {job_id}; last status: {last_status}")
+
+    def _get_transcript(self, conversation_id: str) -> str:
+        response = requests.get(
+            f"{self.base_url}/conversations/{conversation_id}/messages",
+            headers=self._headers(),
+            timeout=30,
+        )
+        if response.status_code != 200:
+            raise Exception(f"Symbl message retrieval failed: {response.text}")
+
+        messages = response.json().get("messages", [])
+        return "\n".join(message.get("text", "") for message in messages if message.get("text"))

--- a/tests/test_symbl.py
+++ b/tests/test_symbl.py
@@ -1,0 +1,115 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from sapat.transcription.symbl import SymblTranscription
+
+
+class SymblTranscriptionTests(unittest.TestCase):
+    def setUp(self):
+        self._env = patch.dict(
+            os.environ,
+            {
+                "SYMBL_ACCESS_TOKEN": "test-token",
+                "SYMBL_API_BASE_URL": "https://symbl.test/v1",
+            },
+            clear=False,
+        )
+        self._env.start()
+
+    def tearDown(self):
+        self._env.stop()
+
+    def _audio_file(self):
+        temp = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        temp.write(b"audio")
+        temp.close()
+        self.addCleanup(lambda: Path(temp.name).exists() and Path(temp.name).unlink())
+        return temp.name
+
+    @staticmethod
+    def _response(status_code, payload=None, text=""):
+        response = Mock()
+        response.status_code = status_code
+        response.text = text
+        response.json.return_value = payload or {}
+        return response
+
+    @patch("sapat.transcription.symbl.requests.get")
+    @patch("sapat.transcription.symbl.requests.post")
+    def test_transcribe_audio_uses_async_job_and_messages(self, mock_post, mock_get):
+        audio_file = self._audio_file()
+        mock_post.return_value = self._response(
+            201,
+            {
+                "jobId": "job-123",
+                "conversationId": "conversation-456",
+            },
+        )
+        mock_get.side_effect = [
+            self._response(200, {"status": "in_progress"}),
+            self._response(200, {"status": "completed"}),
+            self._response(
+                200,
+                {
+                    "messages": [
+                        {"text": "First sentence."},
+                        {"text": "Second sentence."},
+                    ],
+                },
+            ),
+        ]
+
+        transcriber = SymblTranscription(temperature=0.3, poll_interval_seconds=0)
+        result = transcriber.transcribe_audio(audio_file, language="en")
+
+        self.assertEqual(result, {"text": "First sentence.\nSecond sentence."})
+        mock_post.assert_called_once()
+        post_kwargs = mock_post.call_args.kwargs
+        self.assertEqual(post_kwargs["headers"]["Authorization"], "Bearer test-token")
+        self.assertEqual(post_kwargs["headers"]["Content-Type"], "audio/mpeg")
+        self.assertEqual(post_kwargs["params"], {"languageCode": "en-US"})
+        self.assertEqual(mock_get.call_args_list[-1].args[0], "https://symbl.test/v1/conversations/conversation-456/messages")
+
+    @patch("sapat.transcription.symbl.requests.post")
+    def test_generates_access_token_when_missing(self, mock_post):
+        with patch.dict(
+            os.environ,
+            {
+                "SYMBL_ACCESS_TOKEN": "",
+                "SYMBL_APP_ID": "app-id",
+                "SYMBL_APP_SECRET": "app-secret",
+            },
+            clear=False,
+        ):
+            mock_post.return_value = self._response(200, {"accessToken": "generated-token"})
+            transcriber = SymblTranscription(temperature=0.3)
+
+            self.assertEqual(transcriber._get_access_token(), "generated-token")
+            mock_post.assert_called_once_with(
+                "https://api.symbl.ai/oauth2/token:generate",
+                json={
+                    "type": "application",
+                    "appId": "app-id",
+                    "appSecret": "app-secret",
+                },
+                timeout=30,
+            )
+
+    @patch("sapat.transcription.symbl.requests.get")
+    @patch("sapat.transcription.symbl.requests.post")
+    def test_failed_job_raises_error(self, mock_post, mock_get):
+        audio_file = self._audio_file()
+        mock_post.return_value = self._response(201, {"jobId": "job-123", "conversationId": "conversation-456"})
+        mock_get.return_value = self._response(200, {"status": "failed", "message": "bad audio"})
+
+        transcriber = SymblTranscription(temperature=0.3, poll_interval_seconds=0)
+
+        with self.assertRaisesRegex(Exception, "Symbl job failed"):
+            transcriber.transcribe_audio(audio_file, language="en")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a Symbl.ai Async Audio API transcription provider for Sapat.

Scope:
- Adds `--api symbl` CLI routing.
- Supports `SYMBL_ACCESS_TOKEN` or `SYMBL_APP_ID` / `SYMBL_APP_SECRET` token generation.
- Submits MP3 audio to Symbl's async audio endpoint, polls the job, and reads conversation messages into Sapat's existing transcript output path.
- Documents Symbl env vars in README and .env.example.
- Adds mocked unit coverage for submission, polling, transcript retrieval, token generation, and failed jobs.

Validation:
- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v`
- `PYTHONPATH=src .venv/bin/python -m compileall src tests`
- `PYTHONPATH=src .venv/bin/python -m sapat.script --help`
- `git diff --check`

No secrets or media files are included.