### PR TITLE
Add Yandex SpeechKit transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,12 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+YANDEX_API_KEY=
+YANDEX_IAM_TOKEN=
+YANDEX_FOLDER_ID=
+YANDEX_API_ENDPOINT=https://stt.api.cloud.yandex.net/speech/v1/stt:recognize
+YANDEX_LANGUAGE=en-US
+YANDEX_TOPIC=general
+YANDEX_AUDIO_FORMAT=oggopus
+YANDEX_SAMPLE_RATE_HERTZ=48000

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and Yandex SpeechKit APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and Yandex SpeechKit APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - Yandex SpeechKit API
 
 ## Installation
 
@@ -53,7 +54,19 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Yandex SpeechKit
+   YANDEX_API_KEY=your_yandex_api_key_here
+   YANDEX_IAM_TOKEN=
+   YANDEX_FOLDER_ID=
+   YANDEX_API_ENDPOINT=https://stt.api.cloud.yandex.net/speech/v1/stt:recognize
+   YANDEX_LANGUAGE=en-US
+   YANDEX_TOPIC=general
+   YANDEX_AUDIO_FORMAT=oggopus
+   YANDEX_SAMPLE_RATE_HERTZ=48000
    ```
+
+   When authenticating to Yandex SpeechKit with an API key, leave `YANDEX_FOLDER_ID` empty. Set `YANDEX_FOLDER_ID` only when you use an IAM token flow that requires the folder ID.
 
 ## Building and Installing the Package
 
@@ -115,12 +128,15 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api yandex` for Yandex SpeechKit API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
 ```
+
+Yandex SpeechKit synchronous recognition is designed for short, single-channel clips. Sapat converts the temporary MP3 to the OggOpus format required by Yandex before upload. Keep clips within the Yandex synchronous recognition limits, or use a different provider for longer recordings.
 
 - If a file is provided, it will process that single file.
 - If a directory is provided, it will process all `.mp4` files in that directory.
@@ -129,7 +145,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and Yandex SpeechKit). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.yandex import YandexSpeechKitTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'yandex'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'yandex')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "yandex":
+        transcriber = YandexSpeechKitTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/yandex.py
+++ b/src/sapat/transcription/yandex.py
@@ -1,0 +1,212 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class YandexSpeechKitTranscription(TranscriptionBase):
+    """
+    Yandex SpeechKit API implementation for short audio transcription.
+    """
+
+    LANGUAGE_ALIASES = {
+        "en": "en-US",
+        "ru": "ru-RU",
+        "kk": "kk-KZ",
+        "uz": "uz-UZ",
+        "tr": "tr-TR",
+        "de": "de-DE",
+        "fr": "fr-FR",
+        "es": "es-ES",
+        "it": "it-IT",
+    }
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the YandexSpeechKitTranscription class.
+
+        Parameters:
+        - temperature (float): Accepted for CLI compatibility. SpeechKit v1 does not use it.
+        - response_format (str): Accepted for CLI compatibility. SpeechKit v1 returns JSON.
+        """
+        self.api_key = os.getenv("YANDEX_API_KEY")
+        self.iam_token = os.getenv("YANDEX_IAM_TOKEN")
+        self.folder_id = os.getenv("YANDEX_FOLDER_ID")
+        self.endpoint = os.getenv(
+            "YANDEX_API_ENDPOINT",
+            "https://stt.api.cloud.yandex.net/speech/v1/stt:recognize",
+        )
+        self.language = os.getenv("YANDEX_LANGUAGE", "en-US")
+        self.topic = os.getenv("YANDEX_TOPIC", "general")
+        self.audio_format = os.getenv("YANDEX_AUDIO_FORMAT", "oggopus").lower()
+        self.sample_rate_hertz = os.getenv("YANDEX_SAMPLE_RATE_HERTZ", "48000")
+        self.profanity_filter = os.getenv("YANDEX_PROFANITY_FILTER")
+        self.raw_results = os.getenv("YANDEX_RAW_RESULTS")
+        self.temperature = temperature
+        self.response_format = response_format
+        self.max_file_size_mb = float(os.getenv("YANDEX_MAX_FILE_SIZE_MB", "1"))
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Yandex SpeechKit synchronous recognition.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict: The transcription result with a text field compatible with Sapat.
+        """
+        self._validate_audio_file(audio_file)
+        headers = self._build_headers()
+        params = self._build_params(kwargs)
+
+        prepared_file = self._convert_for_yandex(audio_file)
+        try:
+            self._validate_prepared_file(prepared_file)
+            with open(prepared_file, "rb") as f:
+                response = requests.post(
+                    self.endpoint,
+                    headers=headers,
+                    params=params,
+                    data=f,
+                )
+        finally:
+            self._cleanup_prepared_file(prepared_file)
+
+        if response.status_code == 200:
+            payload = response.json()
+            return {"text": payload.get("result", ""), "result": payload.get("result", "")}
+
+        raise Exception(f"Yandex SpeechKit transcription failed: {response.text}")
+
+    def _build_headers(self):
+        if self.api_key:
+            authorization = f"Api-Key {self.api_key}"
+        elif self.iam_token:
+            authorization = f"Bearer {self.iam_token}"
+        else:
+            raise ValueError("Set YANDEX_API_KEY or YANDEX_IAM_TOKEN before using --api yandex.")
+
+        return {
+            "Authorization": authorization,
+            "Content-Type": "application/octet-stream",
+        }
+
+    def _build_params(self, kwargs):
+        language = self._normalize_language(kwargs.get("language", self.language))
+        params = {
+            "lang": language,
+            "topic": kwargs.get("topic", self.topic),
+            "format": self.audio_format,
+        }
+
+        if self.audio_format == "lpcm":
+            params["sampleRateHertz"] = self.sample_rate_hertz
+        if self.folder_id and not self.api_key:
+            params["folderId"] = self.folder_id
+        if self.profanity_filter is not None:
+            params["profanityFilter"] = self.profanity_filter
+        if self.raw_results is not None:
+            params["rawResults"] = self.raw_results
+
+        return params
+
+    def _normalize_language(self, language):
+        if not language:
+            return self.language
+        return self.LANGUAGE_ALIASES.get(str(language).lower(), language)
+
+    def _convert_for_yandex(self, audio_file):
+        if self.audio_format not in {"oggopus", "lpcm"}:
+            raise ValueError("YANDEX_AUDIO_FORMAT must be 'oggopus' or 'lpcm'.")
+
+        suffix = ".ogg" if self.audio_format == "oggopus" else ".lpcm"
+        handle, prepared_file = tempfile.mkstemp(prefix="sapat-yandex-", suffix=suffix)
+        os.close(handle)
+
+        if self.audio_format == "oggopus":
+            command = [
+                "ffmpeg",
+                "-y",
+                "-i",
+                audio_file,
+                "-vn",
+                "-ac",
+                "1",
+                "-ar",
+                "48000",
+                "-c:a",
+                "libopus",
+                "-b:a",
+                "24k",
+                prepared_file,
+            ]
+        else:
+            command = [
+                "ffmpeg",
+                "-y",
+                "-i",
+                audio_file,
+                "-vn",
+                "-ac",
+                "1",
+                "-ar",
+                self.sample_rate_hertz,
+                "-f",
+                "s16le",
+                "-acodec",
+                "pcm_s16le",
+                prepared_file,
+            ]
+
+        try:
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError as exc:
+            self._cleanup_prepared_file(prepared_file)
+            raise Exception("Failed to convert audio for Yandex SpeechKit.") from exc
+
+        return prepared_file
+
+    def _validate_prepared_file(self, audio_file):
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(
+                f"Yandex SpeechKit synchronous recognition supports files up to "
+                f"{self.max_file_size_mb} MB. Use a shorter clip or an async provider."
+            )
+
+    def _cleanup_prepared_file(self, audio_file):
+        try:
+            Path(audio_file).unlink(missing_ok=True)
+        except TypeError:
+            path = Path(audio_file)
+            if path.exists():
+                path.unlink()
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        valid_extensions = [
+            ".mp3",
+            ".wav",
+            ".flac",
+            ".ogg",
+            ".opus",
+            ".m4a",
+            ".aac",
+            ".mp4",
+            ".webm",
+            ".mov",
+        ]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}.")

--- a/tests/test_yandex.py
+++ b/tests/test_yandex.py
@@ -1,0 +1,117 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+from sapat.transcription.yandex import YandexSpeechKitTranscription
+
+
+class YandexSpeechKitTranscriptionTests(unittest.TestCase):
+    def setUp(self):
+        self.env = {
+            "YANDEX_API_KEY": "test-api-key",
+            "YANDEX_IAM_TOKEN": "",
+            "YANDEX_FOLDER_ID": "folder-123",
+            "YANDEX_API_ENDPOINT": "https://stt.api.cloud.yandex.net/speech/v1/stt:recognize",
+            "YANDEX_LANGUAGE": "en-US",
+            "YANDEX_TOPIC": "general",
+            "YANDEX_AUDIO_FORMAT": "oggopus",
+        }
+
+    def _write_prepared_file(self, command, check):
+        Path(command[-1]).write_bytes(b"fake oggopus")
+
+    def test_transcribe_audio_posts_binary_audio_and_options(self):
+        response = Mock(status_code=200)
+        response.json.return_value = {"result": "hello world"}
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file, patch.dict(os.environ, self.env, clear=False), patch(
+            "sapat.transcription.yandex.subprocess.run", side_effect=self._write_prepared_file
+        ) as ffmpeg, patch("sapat.transcription.yandex.requests.post", return_value=response) as post:
+            audio_file.write(b"fake audio")
+            audio_file.flush()
+
+            result = YandexSpeechKitTranscription(temperature=0.3).transcribe_audio(audio_file.name, language="en")
+
+        self.assertEqual(result, {"text": "hello world", "result": "hello world"})
+        ffmpeg.assert_called_once()
+        self.assertFalse(Path(ffmpeg.call_args.args[0][-1]).exists())
+        self.assertEqual(post.call_args.args[0], "https://stt.api.cloud.yandex.net/speech/v1/stt:recognize")
+        self.assertEqual(
+            post.call_args.kwargs["headers"],
+            {
+                "Authorization": "Api-Key test-api-key",
+                "Content-Type": "application/octet-stream",
+            },
+        )
+        self.assertEqual(
+            post.call_args.kwargs["params"],
+            {
+                "lang": "en-US",
+                "topic": "general",
+                "format": "oggopus",
+            },
+        )
+
+    def test_transcribe_audio_supports_iam_token_auth_with_folder_id(self):
+        response = Mock(status_code=200)
+        response.json.return_value = {"result": "token auth"}
+        env = {
+            "YANDEX_API_KEY": "",
+            "YANDEX_IAM_TOKEN": "iam-token",
+            "YANDEX_FOLDER_ID": "folder-123",
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file, patch.dict(os.environ, env, clear=False), patch(
+            "sapat.transcription.yandex.subprocess.run", side_effect=self._write_prepared_file
+        ), patch("sapat.transcription.yandex.requests.post", return_value=response) as post:
+            audio_file.write(b"fake audio")
+            audio_file.flush()
+
+            result = YandexSpeechKitTranscription(temperature=0.3).transcribe_audio(audio_file.name)
+
+        self.assertEqual(result["text"], "token auth")
+        self.assertEqual(post.call_args.kwargs["headers"]["Authorization"], "Bearer iam-token")
+        self.assertEqual(post.call_args.kwargs["params"]["folderId"], "folder-123")
+
+    def test_transcribe_audio_requires_auth(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file, patch.dict(
+            os.environ, {"YANDEX_API_KEY": "", "YANDEX_IAM_TOKEN": ""}, clear=False
+        ):
+            audio_file.write(b"fake audio")
+            audio_file.flush()
+
+            with self.assertRaises(ValueError):
+                YandexSpeechKitTranscription(temperature=0.3).transcribe_audio(audio_file.name)
+
+    def test_transcribe_audio_raises_api_errors(self):
+        response = Mock(status_code=401, text="unauthorized")
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio_file, patch.dict(os.environ, self.env, clear=False), patch(
+            "sapat.transcription.yandex.subprocess.run", side_effect=self._write_prepared_file
+        ), patch("sapat.transcription.yandex.requests.post", return_value=response):
+            audio_file.write(b"fake audio")
+            audio_file.flush()
+
+            with self.assertRaisesRegex(Exception, "Yandex SpeechKit transcription failed"):
+                YandexSpeechKitTranscription(temperature=0.3).transcribe_audio(audio_file.name)
+
+    def test_cli_routes_to_yandex_transcriber(self):
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video_file, patch(
+            "sapat.script.YandexSpeechKitTranscription"
+        ) as transcriber:
+            result = runner.invoke(main, [video_file.name, "--api", "yandex"])
+
+        self.assertEqual(result.exit_code, 0)
+        transcriber.assert_called_once_with(temperature=0.3)
+        transcriber.return_value.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `--api yandex` routing for Yandex SpeechKit synchronous recognition
- convert Sapat's temporary MP3 output to Yandex-compatible OggOpus or LPCM before upload
- document `YANDEX_*` environment variables and add mocked provider/CLI tests

## Notes

Yandex SpeechKit API v1 synchronous recognition is intentionally scoped to short, single-channel audio. The provider enforces the documented size guard after conversion and the README calls out the short-clip limitation.

## Validation

- `.\.venv\Scripts\python -m unittest discover -s tests -v`
- `.\.venv\Scripts\python -m compileall src tests`
- `.\.venv\Scripts\sapat.exe --help`
- local FFmpeg OggOpus conversion smoke check
- `git diff --check`

No secrets, private media, payout details, or generated transcripts are included.

Related Daytona bounty attempt: https://github.com/daytonaio/content/issues/13#issuecomment-4553704844