### PR TITLE
Add Moonshine transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This tool automates the process of transcribing video files using multiple trans
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and local Moonshine Voice
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,8 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+- Optional local Moonshine Voice support:
+  - `pip install 'sapat[moonshine]'`
 
 ## Installation
 
@@ -53,6 +55,10 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Moonshine Voice
+   # No API key is required. The moonshine-voice package downloads and caches
+   # the selected local model when you run the provider for the first time.
    ```
 
 ## Building and Installing the Package
@@ -115,12 +121,24 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api moonshine` for local Moonshine Voice transcription
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
 ```
+
+Local Moonshine example:
+
+```
+pip install 'sapat[moonshine]'
+sapat my_video.mp4 --language en --api moonshine
+```
+
+Moonshine runs on-device and does not use `--prompt`, `--temperature`, or
+`--correct`. Sapat converts video or audio input to a temporary 16 kHz mono WAV
+file before calling Moonshine.
 
 - If a file is provided, it will process that single file.
 - If a directory is provided, it will process all `.mp4` files in that directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "groq>=0.13.1"
 ]
 
+[project.optional-dependencies]
+moonshine = [
+    "moonshine-voice>=0.0.56"
+]
+
 [project.scripts]
 sapat = "sapat.script:main"
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.moonshine import MoonshineTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'moonshine'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'moonshine')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "moonshine":
+        transcriber = MoonshineTranscription()
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/base.py
+++ b/src/sapat/transcription/base.py
@@ -31,6 +31,26 @@ class TranscriptionBase(ABC):
         command = ['ffmpeg', '-i', input_file, '-vn'] + ffmpeg_options + [output_file]
         subprocess.run(command, check=True)
 
+    @staticmethod
+    def convert_to_wav(input_file: str, output_file: str):
+        """
+        Converts an audio or video file to 16 kHz mono WAV for local ASR engines.
+        """
+        command = [
+            'ffmpeg',
+            '-i',
+            input_file,
+            '-vn',
+            '-ar',
+            '16000',
+            '-ac',
+            '1',
+            '-sample_fmt',
+            's16',
+            output_file,
+        ]
+        subprocess.run(command, check=True)
+
 
     def process_file(self, input_file, language, prompt, temperature, quality, correct):
         input_path = Path(input_file)

--- a/src/sapat/transcription/moonshine.py
+++ b/src/sapat/transcription/moonshine.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import click
+
+from .base import TranscriptionBase
+
+
+class MoonshineTranscription(TranscriptionBase):
+    """
+    Moonshine Voice implementation for local, on-device transcription.
+    """
+
+    def __init__(self, update_interval: float = 0.5):
+        self.update_interval = update_interval
+
+    def process_file(self, input_file, language, prompt, temperature, quality, correct):
+        if correct:
+            raise click.ClickException(
+                "Moonshine does not implement transcript correction. "
+                "Run without --correct or use openai, groq, or azure."
+            )
+
+        input_path = Path(input_file)
+        txt_file = input_path.with_suffix('.txt')
+        wav_file = input_path if input_path.suffix.lower() == '.wav' else input_path.with_suffix('.wav')
+        created_wav = False
+
+        click.echo(f"Processing {input_file}")
+
+        if input_path.suffix.lower() != '.wav':
+            if not wav_file.exists():
+                self.convert_to_wav(str(input_path), str(wav_file))
+                created_wav = True
+                click.echo("Conversion to WAV completed")
+            else:
+                click.echo("WAV file already exists, skipping conversion")
+
+        transcription_result = self.transcribe_audio(str(wav_file), language=language)
+        click.echo("Transcription completed")
+
+        with open(txt_file, 'w', encoding='utf-8') as f:
+            f.write(transcription_result)
+        click.echo(f"Transcription saved to {txt_file}")
+
+        if created_wav:
+            wav_file.unlink()
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        try:
+            from moonshine_voice import Transcriber, get_model_for_language, load_wav_file
+        except ImportError as exc:
+            raise ImportError(
+                "Moonshine support requires the optional moonshine-voice package. "
+                "Install it with `pip install 'sapat[moonshine]'` or "
+                "`pip install moonshine-voice`."
+            ) from exc
+
+        language = kwargs.get("language") or "en"
+        model_path, model_arch = get_model_for_language(language)
+        audio_data, sample_rate = load_wav_file(audio_file)
+        transcriber = Transcriber(
+            model_path=model_path,
+            model_arch=model_arch,
+            update_interval=self.update_interval,
+        )
+
+        try:
+            transcript = transcriber.transcribe_without_streaming(audio_data, sample_rate)
+            return self._transcript_to_text(transcript)
+        finally:
+            close = getattr(transcriber, "close", None)
+            if callable(close):
+                close()
+
+    @staticmethod
+    def _transcript_to_text(transcript):
+        lines = getattr(transcript, "lines", None)
+        if lines is None:
+            return str(transcript)
+
+        ordered_lines = sorted(lines, key=lambda line: getattr(line, "start_time", 0.0))
+        return "\n".join(
+            getattr(line, "text", str(line)).strip()
+            for line in ordered_lines
+            if getattr(line, "text", str(line)).strip()
+        )

--- a/tests/test_moonshine.py
+++ b/tests/test_moonshine.py
@@ -1,0 +1,111 @@
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from click.testing import CliRunner
+
+from sapat.script import main
+from sapat.transcription.moonshine import MoonshineTranscription
+
+
+class FakeLine:
+    def __init__(self, text, start_time):
+        self.text = text
+        self.start_time = start_time
+
+
+class FakeTranscriber:
+    last_instance = None
+
+    def __init__(self, model_path, model_arch, update_interval):
+        self.model_path = model_path
+        self.model_arch = model_arch
+        self.update_interval = update_interval
+        self.closed = False
+        FakeTranscriber.last_instance = self
+
+    def transcribe_without_streaming(self, audio_data, sample_rate):
+        self.audio_data = audio_data
+        self.sample_rate = sample_rate
+        return types.SimpleNamespace(
+            lines=[
+                FakeLine("second line", 2.0),
+                FakeLine("first line", 1.0),
+            ]
+        )
+
+    def close(self):
+        self.closed = True
+
+
+class MoonshineTranscriptionTests(unittest.TestCase):
+    def test_transcript_lines_are_written_in_chronological_order(self):
+        transcript = types.SimpleNamespace(
+            lines=[
+                FakeLine("later", 4.0),
+                FakeLine("earlier", 1.0),
+                FakeLine(" ", 2.0),
+            ]
+        )
+
+        result = MoonshineTranscription._transcript_to_text(transcript)
+
+        self.assertEqual(result, "earlier\nlater")
+
+    def test_transcribe_audio_uses_moonshine_voice_package(self):
+        fake_module = types.SimpleNamespace(
+            Transcriber=FakeTranscriber,
+            get_model_for_language=lambda language: (f"/models/{language}", "base"),
+            load_wav_file=lambda audio_file: ([0.1, -0.1], 16000),
+        )
+
+        with mock.patch.dict(sys.modules, {"moonshine_voice": fake_module}):
+            result = MoonshineTranscription(update_interval=0.25).transcribe_audio(
+                "speech.wav",
+                language="en",
+            )
+
+        self.assertEqual(result, "first line\nsecond line")
+        self.assertEqual(FakeTranscriber.last_instance.model_path, "/models/en")
+        self.assertEqual(FakeTranscriber.last_instance.model_arch, "base")
+        self.assertEqual(FakeTranscriber.last_instance.update_interval, 0.25)
+        self.assertTrue(FakeTranscriber.last_instance.closed)
+
+    def test_missing_moonshine_dependency_has_actionable_message(self):
+        with mock.patch.dict(sys.modules, {"moonshine_voice": None}):
+            with self.assertRaises(ImportError) as raised:
+                MoonshineTranscription().transcribe_audio("speech.wav", language="en")
+
+        self.assertIn("pip install 'sapat[moonshine]'", str(raised.exception))
+
+    def test_process_file_converts_to_temporary_wav_and_removes_it(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = Path(tmpdir) / "demo.mp4"
+            video_path.write_bytes(b"not really video")
+            wav_path = video_path.with_suffix(".wav")
+            txt_path = video_path.with_suffix(".txt")
+            transcriber = MoonshineTranscription()
+
+            def fake_convert(input_file, output_file):
+                self.assertEqual(input_file, str(video_path))
+                Path(output_file).write_bytes(b"wav")
+
+            with mock.patch.object(transcriber, "convert_to_wav", side_effect=fake_convert):
+                with mock.patch.object(transcriber, "transcribe_audio", return_value="hello"):
+                    transcriber.process_file(video_path, "en", None, 0.3, "M", False)
+
+            self.assertEqual(txt_path.read_text(encoding="utf-8"), "hello")
+            self.assertFalse(wav_path.exists())
+
+    def test_cli_exposes_moonshine_api_choice(self):
+        result = CliRunner().invoke(main, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("moonshine", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a local Moonshine Voice transcription provider behind `--api moonshine` so Sapat can run on-device speech-to-text without a cloud API key.

## Changes

- Adds `MoonshineTranscription` with lazy `moonshine_voice` imports.
- Converts non-WAV inputs to a temporary 16 kHz mono WAV file before transcription.
- Wires `--api moonshine` into the CLI and README.
- Adds an optional `moonshine` package extra.
- Adds focused unit tests with a fake Moonshine module, so tests do not download models.

## Validation

- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v`
- `PYTHONPYCACHEPREFIX=.pycache .venv/bin/python -m py_compile src/sapat/script.py src/sapat/transcription/base.py src/sapat/transcription/moonshine.py tests/test_moonshine.py`
- `.venv/bin/sapat --help`
- `git diff --check`

No secrets, model files, generated transcripts, or private media are included.
