### PR TITLE
Add xAI speech-to-text provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,10 @@ OPENAI_API_KEY=
 OPENAI_MODEL=whisper-1
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
 OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+XAI_API_KEY=
+XAI_STT_API_ENDPOINT=https://api.x.ai/v1/stt
+XAI_STT_FORMAT=true
+XAI_STT_KEYTERMS=
+XAI_STT_DIARIZE=false
+XAI_STT_MULTICHANNEL=false

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and xAI Speech-to-Text APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and xAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - xAI API
 
 ## Installation
 
@@ -53,6 +54,14 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # xAI Speech-to-Text
+   XAI_API_KEY=your_xai_api_key_here
+   XAI_STT_API_ENDPOINT=https://api.x.ai/v1/stt
+   XAI_STT_FORMAT=true
+   XAI_STT_KEYTERMS=Daytona,Sapat
+   XAI_STT_DIARIZE=false
+   XAI_STT_MULTICHANNEL=false
    ```
 
 ## Building and Installing the Package
@@ -115,12 +124,21 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api xai` for xAI Speech-to-Text API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
 ```
+
+Using xAI Speech-to-Text:
+
+```
+sapat my_video.mp4 --quality M --language en --api xai
+```
+
+The xAI provider uses `XAI_API_KEY` and posts to `https://api.x.ai/v1/stt` by default. Set `XAI_STT_KEYTERMS` to a comma-separated list of product names or proper nouns to bias transcription, and set `XAI_STT_DIARIZE=true` when you want word-level speaker labels in the response. xAI does not use Sapat's `--prompt` or `--temperature` values for transcription.
 
 - If a file is provided, it will process that single file.
 - If a directory is provided, it will process all `.mp4` files in that directory.
@@ -129,7 +147,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, OpenAI, and xAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.xai import XAITranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'xai'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'xai')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "xai":
+        transcriber = XAITranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/xai.py
+++ b/src/sapat/transcription/xai.py
@@ -1,0 +1,150 @@
+import mimetypes
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+# Load environment variables
+load_dotenv(".env")
+
+
+class XAITranscription(TranscriptionBase):
+    """
+    xAI Speech-to-Text API implementation for transcription.
+    """
+
+    def __init__(self, temperature: float):
+        """
+        Initializes the XAITranscription class.
+
+        Parameters:
+        - temperature (float): Accepted for CLI compatibility with other providers.
+        """
+        self.api_key = os.getenv("XAI_API_KEY")
+        self.endpoint = os.getenv("XAI_STT_API_ENDPOINT", "https://api.x.ai/v1/stt")
+        self.temperature = temperature
+        self.max_file_size_mb = 500
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using xAI Speech-to-Text.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict: The transcription result from xAI.
+        """
+        self._validate_configuration()
+        self._validate_audio_file(audio_file)
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        data = self._build_data(**kwargs)
+
+        with open(audio_file, "rb") as f:
+            files = {
+                "file": (
+                    os.path.basename(audio_file),
+                    f,
+                    mimetypes.guess_type(audio_file)[0] or "application/octet-stream",
+                )
+            }
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                data=data,
+                files=files,
+            )
+
+        if 200 <= response.status_code < 300:
+            return response.json()
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def _validate_configuration(self):
+        if not self.api_key:
+            raise ValueError("XAI_API_KEY is required for xAI transcription.")
+
+    def _build_data(self, **kwargs):
+        data = [("format", self._bool_value(os.getenv("XAI_STT_FORMAT", "true")))]
+
+        language = kwargs.get("language") or os.getenv("XAI_STT_LANGUAGE")
+        if language:
+            data.append(("language", language))
+
+        for env_name, field_name in [
+            ("XAI_STT_DIARIZE", "diarize"),
+            ("XAI_STT_MULTICHANNEL", "multichannel"),
+            ("XAI_STT_FILLER_WORDS", "filler_words"),
+        ]:
+            value = os.getenv(env_name)
+            if value:
+                data.append((field_name, self._bool_value(value)))
+
+        for env_name, field_name in [
+            ("XAI_STT_CHANNELS", "channels"),
+            ("XAI_STT_AUDIO_FORMAT", "audio_format"),
+            ("XAI_STT_SAMPLE_RATE", "sample_rate"),
+        ]:
+            value = os.getenv(env_name)
+            if value:
+                data.append((field_name, value))
+
+        for keyterm in self._keyterms(kwargs.get("keyterms")):
+            data.append(("keyterm", keyterm))
+
+        return data
+
+    @staticmethod
+    def _bool_value(value):
+        return "true" if str(value).strip().lower() in {"1", "true", "yes", "on"} else "false"
+
+    @staticmethod
+    def _keyterms(value=None):
+        keyterms = value
+        if keyterms is None:
+            keyterms = os.getenv("XAI_STT_KEYTERMS", "")
+
+        if isinstance(keyterms, str):
+            parts = keyterms.split(",")
+        else:
+            parts = list(keyterms)
+
+        return [part.strip() for part in parts if part and part.strip()]
+
+    def _validate_audio_file(self, audio_file: str):
+        """
+        Validates the audio file for size and format.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+
+        Raises:
+        - Exception: If the file is invalid.
+        """
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [
+            ".mp3",
+            ".wav",
+            ".flac",
+            ".ogg",
+            ".opus",
+            ".aac",
+            ".mp4",
+            ".m4a",
+            ".mkv",
+        ]
+        if not any(str(audio_file).endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}."
+            )

--- a/tests/test_xai.py
+++ b/tests/test_xai.py
@@ -1,0 +1,99 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+
+class XAITranscriptionTests(unittest.TestCase):
+    def _audio_file(self, suffix=".mp3"):
+        handle = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        handle.write(b"audio")
+        handle.close()
+        self.addCleanup(lambda: os.path.exists(handle.name) and os.unlink(handle.name))
+        return handle.name
+
+    def test_transcribe_audio_posts_to_xai_stt_with_file_last(self):
+        from sapat.transcription.xai import XAITranscription
+
+        audio_file = self._audio_file()
+        response = Mock(status_code=200)
+        response.json.return_value = {"text": "hello", "duration": 1.25, "words": []}
+
+        env = {
+            "XAI_API_KEY": "test-key",
+            "XAI_STT_KEYTERMS": "Daytona,Sapat",
+            "XAI_STT_DIARIZE": "true",
+            "XAI_STT_MULTICHANNEL": "false",
+        }
+
+        with patch.dict(os.environ, env, clear=True), patch(
+            "sapat.transcription.xai.requests.post", return_value=response
+        ) as post:
+            result = XAITranscription(temperature=0.3).transcribe_audio(
+                audio_file, language="en"
+            )
+
+        self.assertEqual(result["text"], "hello")
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        self.assertEqual(post.call_args.args[0], "https://api.x.ai/v1/stt")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(
+            kwargs["data"],
+            [
+                ("format", "true"),
+                ("language", "en"),
+                ("diarize", "true"),
+                ("multichannel", "false"),
+                ("keyterm", "Daytona"),
+                ("keyterm", "Sapat"),
+            ],
+        )
+        self.assertEqual(list(kwargs["files"].keys()), ["file"])
+        self.assertEqual(kwargs["files"]["file"][0], os.path.basename(audio_file))
+
+    def test_transcribe_audio_requires_api_key(self):
+        from sapat.transcription.xai import XAITranscription
+
+        audio_file = self._audio_file()
+
+        with patch.dict(os.environ, {"XAI_API_KEY": ""}, clear=True):
+            transcriber = XAITranscription(temperature=0.3)
+            with self.assertRaisesRegex(ValueError, "XAI_API_KEY"):
+                transcriber.transcribe_audio(audio_file, language="en")
+
+    def test_transcribe_audio_rejects_oversized_files(self):
+        from sapat.transcription.xai import XAITranscription
+
+        audio_file = self._audio_file()
+
+        with patch.dict(os.environ, {"XAI_API_KEY": "test-key"}, clear=True), patch(
+            "sapat.transcription.xai.os.path.getsize",
+            return_value=(501 * 1024 * 1024),
+        ):
+            transcriber = XAITranscription(temperature=0.3)
+            with self.assertRaisesRegex(Exception, "500 MB"):
+                transcriber.transcribe_audio(audio_file, language="en")
+
+    def test_cli_accepts_xai_provider(self):
+        from sapat import script
+
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            with open("clip.mp4", "wb") as f:
+                f.write(b"video")
+
+            with patch.object(script, "XAITranscription") as transcriber_cls:
+                transcriber = transcriber_cls.return_value
+                result = runner.invoke(script.main, ["clip.mp4", "--api", "xai"])
+
+        self.assertEqual(result.exit_code, 0)
+        transcriber_cls.assert_called_once_with(temperature=0.3)
+        transcriber.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an xAI Speech-to-Text provider as `--api xai`, posting to `https://api.x.ai/v1/stt`
- map xAI STT options from env vars, including formatting, diarization, multichannel mode, and repeated `keyterm` fields
- document xAI configuration and add mocked regression tests for request construction, missing credentials, size validation, and CLI routing

## Validation
- `venv/bin/python -m unittest discover -s tests -v`
- `venv/bin/python -m compileall src tests`
- `venv/bin/sapat --help`
- `git diff --check`

No secrets, private audio, generated transcripts, or payout details are included.