### PR TITLE
Add OpenRouter speech-to-text provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, OpenAI, and OpenRouter APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, OpenAI, and OpenRouter APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -18,6 +18,7 @@ This tool automates the process of transcribing video files using multiple trans
   - Azure OpenAI API
   - Groq Cloud API
   - OpenAI API
+  - OpenRouter API
 
 ## Installation
 
@@ -53,6 +54,14 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # OpenRouter
+   OPENROUTER_API_KEY=your_openrouter_api_key_here
+   OPENROUTER_MODEL=openai/whisper-large-v3
+   OPENROUTER_API_ENDPOINT=https://openrouter.ai/api/v1/audio/transcriptions
+   # Optional attribution headers for OpenRouter rankings/analytics
+   OPENROUTER_HTTP_REFERER=https://github.com/nkkko/sapat
+   OPENROUTER_APP_TITLE=Sapat
    ```
 
 ## Building and Installing the Package
@@ -115,6 +124,7 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
    - `--api openai` for OpenAI API
+   - `--api openrouter` for OpenRouter API
 
 Example:
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
 from .transcription.openai import OpenAITranscription
+from .transcription.openrouter import OpenRouterTranscription
 
 @click.command()
 @click.argument("input_path", type=click.Path(exists=True))
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'openrouter'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'openrouter')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "openrouter":
+        transcriber = OpenRouterTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/openrouter.py
+++ b/src/sapat/transcription/openrouter.py
@@ -1,0 +1,93 @@
+import base64
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class OpenRouterTranscription(TranscriptionBase):
+    """
+    OpenRouter API implementation for speech-to-text transcription.
+    """
+
+    def __init__(self, temperature: float):
+        self.api_key = os.getenv("OPENROUTER_API_KEY")
+        self.endpoint = os.getenv(
+            "OPENROUTER_API_ENDPOINT",
+            "https://openrouter.ai/api/v1/audio/transcriptions",
+        )
+        self.model = os.getenv("OPENROUTER_MODEL", "openai/whisper-large-v3")
+        self.http_referer = os.getenv("OPENROUTER_HTTP_REFERER")
+        self.app_title = os.getenv("OPENROUTER_APP_TITLE")
+        self.temperature = temperature
+        self.max_file_size_mb = 25
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using OpenRouter's transcription API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict: The transcription response.
+        """
+        self._validate_audio_file(audio_file)
+
+        with open(audio_file, "rb") as f:
+            encoded_audio = base64.b64encode(f.read()).decode("ascii")
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        if self.http_referer:
+            headers["HTTP-Referer"] = self.http_referer
+        if self.app_title:
+            headers["X-Title"] = self.app_title
+
+        payload = {
+            "input_audio": {
+                "data": encoded_audio,
+                "format": os.path.splitext(audio_file)[1].lstrip(".").lower(),
+            },
+            "model": kwargs.get("model", self.model),
+            "temperature": kwargs.get("temperature", self.temperature),
+        }
+
+        language = kwargs.get("language")
+        if language:
+            payload["language"] = language
+
+        response = requests.post(self.endpoint, headers=headers, json=payload)
+
+        if response.status_code == 200:
+            return response.json()
+
+        raise Exception(f"Transcription failed: {response.text}")
+
+    def generate_corrected_transcript(self, audio_file: str, temperature: float, system_prompt: str):
+        raise NotImplementedError("Correction is not implemented for OpenRouter.")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not self.api_key:
+            raise ValueError("OPENROUTER_API_KEY is required.")
+
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(f"File size exceeds the maximum limit of {self.max_file_size_mb} MB.")
+
+        valid_extensions = [".mp3", ".wav", ".flac", ".m4a", ".aac", ".ogg"]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. Supported formats are {valid_extensions}."
+            )

--- a/tests/test_openrouter_transcription.py
+++ b/tests/test_openrouter_transcription.py
@@ -1,0 +1,64 @@
+import base64
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from sapat.transcription.openrouter import OpenRouterTranscription
+
+
+class OpenRouterTranscriptionTest(unittest.TestCase):
+    def setUp(self):
+        self.original_env = os.environ.copy()
+        os.environ["OPENROUTER_API_KEY"] = "test-key"
+        os.environ["OPENROUTER_MODEL"] = "openai/whisper-large-v3"
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    @patch("sapat.transcription.openrouter.requests.post")
+    def test_transcribe_audio_posts_base64_payload(self, post):
+        response = Mock(status_code=200)
+        response.json.return_value = {"text": "hello from openrouter"}
+        post.return_value = response
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            audio.write(b"audio bytes")
+            audio.flush()
+
+            result = OpenRouterTranscription(temperature=0.2).transcribe_audio(
+                audio.name,
+                language="en",
+                temperature=0.4,
+            )
+
+        self.assertEqual(result, {"text": "hello from openrouter"})
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(kwargs["headers"]["Content-Type"], "application/json")
+        self.assertEqual(kwargs["json"]["model"], "openai/whisper-large-v3")
+        self.assertEqual(kwargs["json"]["language"], "en")
+        self.assertEqual(kwargs["json"]["temperature"], 0.4)
+        self.assertEqual(kwargs["json"]["input_audio"]["format"], "mp3")
+        self.assertEqual(
+            kwargs["json"]["input_audio"]["data"],
+            base64.b64encode(b"audio bytes").decode("ascii"),
+        )
+
+    def test_missing_api_key_raises_clear_error(self):
+        os.environ.pop("OPENROUTER_API_KEY")
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3") as audio:
+            with self.assertRaisesRegex(ValueError, "OPENROUTER_API_KEY"):
+                OpenRouterTranscription(temperature=0.2).transcribe_audio(audio.name)
+
+    def test_unsupported_extension_raises(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt") as audio:
+            with self.assertRaisesRegex(ValueError, "Unsupported audio file format"):
+                OpenRouterTranscription(temperature=0.2).transcribe_audio(audio.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,24 @@
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from sapat.script import main
+
+
+class ScriptTest(unittest.TestCase):
+    @patch("sapat.script.OpenRouterTranscription")
+    def test_openrouter_cli_route(self, transcriber_class):
+        transcriber = transcriber_class.return_value
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as video:
+            result = CliRunner().invoke(main, [video.name, "--api", "openrouter"])
+
+        self.assertEqual(result.exit_code, 0)
+        transcriber_class.assert_called_once_with(temperature=0.3)
+        transcriber.process_file.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an OpenRouter transcription provider using the official base64 audio transcription endpoint
- wire `--api openrouter` into the CLI and README configuration
- add mocked unit tests for request construction, validation, and CLI routing

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m compileall src tests`
- `git diff --check`

No secrets or media files are included.