### PR TITLE
Add Lemonfox transcription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Video Transcription Tool
 
-This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
+This tool automates the process of transcribing video files using multiple transcription services: Azure OpenAI, Groq, Lemonfox, and OpenAI APIs. It converts video files to MP3 format, transcribes the audio, and saves the transcription as a text file.
 
 ## Features
 
 - Converts video files to MP3 format using ffmpeg
-- Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
+- Supports transcription using Azure OpenAI, Groq, Lemonfox, and OpenAI APIs
 - Supports processing of individual video files or entire directories
 - Cleans up temporary MP3 files after transcription
 - Provides flexibility in selecting the transcription service via configuration
@@ -17,6 +17,7 @@ This tool automates the process of transcribing video files using multiple trans
 - API access for one or more supported services:
   - Azure OpenAI API
   - Groq Cloud API
+  - Lemonfox API
   - OpenAI API
 
 ## Installation
@@ -53,6 +54,15 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_MODEL=whisper-1
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
+
+   # Lemonfox
+   LEMONFOX_API_KEY=your_lemonfox_api_key_here
+   LEMONFOX_API_ENDPOINT=https://api.lemonfox.ai/v1/audio/transcriptions
+   LEMONFOX_RESPONSE_FORMAT=json
+   # Optional: set to true to request diarized verbose_json output.
+   LEMONFOX_SPEAKER_LABELS=false
+   # Optional: set to true to translate audio to English.
+   LEMONFOX_TRANSLATE=false
    ```
 
 ## Building and Installing the Package
@@ -114,12 +124,19 @@ sapat <video_file_or_directory> [--language <language>] [--prompt <prompt>] [--t
 - `--api`: Specify the API to use for transcription.
    - `--api azure` for Azure OpenAI API
    - `--api groq` for Groq Cloud API
+   - `--api lemonfox` for Lemonfox API
    - `--api openai` for OpenAI API
 
 Example:
 
 ```
 sapat my_video.mp4 --quality H --language es --prompt "This is a test prompt" --temperature 0.5 --api groq
+```
+
+Lemonfox example:
+
+```
+sapat my_video.mp4 --quality M --language en --prompt "NFT, DeFi, DAO" --api lemonfox
 ```
 
 - If a file is provided, it will process that single file.
@@ -129,7 +146,7 @@ The script will create a `.txt` file with the same name as the input video file,
 
 ## Note
 
-This tool is designed for use with multiple APIs (Azure OpenAI, Groq, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
+This tool is designed for use with multiple APIs (Azure OpenAI, Groq, Lemonfox, and OpenAI). Ensure you have valid API credentials configured in the `.env` file and the necessary permissions and credits for the API service you plan to use.
 
 ## License
 

--- a/src/sapat/script.py
+++ b/src/sapat/script.py
@@ -2,6 +2,7 @@ import click
 from pathlib import Path
 from .transcription.groq import GroqCloudTranscription
 from .transcription.azure import AzureTranscription
+from .transcription.lemonfox import LemonfoxTranscription
 from .transcription.openai import OpenAITranscription
 
 @click.command()
@@ -11,7 +12,7 @@ from .transcription.openai import OpenAITranscription
 @click.option("--temperature", "-t", type=float, default=0.3, help="Sampling temperature (default: 0.3)")
 @click.option("--quality", "-q", type=click.Choice(['L', 'M', 'H'], case_sensitive=False), default='M', help="Quality of the MP3 audio: 'L' for low, 'M' for medium, and 'H' for high (default: 'M')")
 @click.option("--correct", is_flag=True, help="Use LLM to correct the transcript")
-@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq' or 'azure')")
+@click.option("--api", "-a", type=click.Choice(['openai', 'groq', 'azure', 'lemonfox'], case_sensitive=True), required=True, help="API to use for the transcription ('openai', 'groq', 'azure' or 'lemonfox')")
 def main(input_path, language, prompt, temperature, quality, correct, api):
     """
     Transcribe video files using different APIs.
@@ -28,6 +29,8 @@ def main(input_path, language, prompt, temperature, quality, correct, api):
         transcriber = AzureTranscription(temperature=temperature)
     elif api.lower() == "openai":
         transcriber = OpenAITranscription(temperature=temperature)
+    elif api.lower() == "lemonfox":
+        transcriber = LemonfoxTranscription(temperature=temperature)
     else:
         click.echo(f"Unsupported API: {api}")
         return

--- a/src/sapat/transcription/lemonfox.py
+++ b/src/sapat/transcription/lemonfox.py
@@ -1,0 +1,149 @@
+import os
+
+import requests
+from dotenv import load_dotenv
+
+from .base import TranscriptionBase
+
+
+load_dotenv(".env")
+
+
+class LemonfoxTranscription(TranscriptionBase):
+    """
+    Lemonfox API implementation for transcription.
+    """
+
+    LANGUAGE_ALIASES = {
+        "en": "english",
+        "zh": "chinese",
+        "de": "german",
+        "es": "spanish",
+        "ru": "russian",
+        "ko": "korean",
+        "fr": "french",
+        "ja": "japanese",
+        "pt": "portuguese",
+        "tr": "turkish",
+        "pl": "polish",
+        "nl": "dutch",
+        "ar": "arabic",
+        "sv": "swedish",
+        "it": "italian",
+        "id": "indonesian",
+        "hi": "hindi",
+        "fi": "finnish",
+        "vi": "vietnamese",
+        "he": "hebrew",
+        "uk": "ukrainian",
+        "el": "greek",
+    }
+
+    def __init__(self, temperature: float, response_format: str = "json"):
+        """
+        Initializes the LemonfoxTranscription class.
+
+        Parameters:
+        - temperature (float): Accepted for CLI compatibility. Lemonfox does not
+          currently expose a temperature parameter for transcription.
+        - response_format (str): Default response format for transcription.
+        """
+        self.api_key = os.getenv("LEMONFOX_API_KEY")
+        self.endpoint = os.getenv(
+            "LEMONFOX_API_ENDPOINT",
+            "https://api.lemonfox.ai/v1/audio/transcriptions",
+        )
+        self.temperature = temperature
+        self.response_format = os.getenv("LEMONFOX_RESPONSE_FORMAT", response_format)
+        self.max_file_size_mb = 100
+
+    def transcribe_audio(self, audio_file: str, **kwargs):
+        """
+        Transcribes an audio file using Lemonfox's OpenAI-compatible API.
+
+        Parameters:
+        - audio_file (str): Path to the audio file.
+        - kwargs: Additional parameters for transcription.
+
+        Returns:
+        - dict or str: The transcription result.
+        """
+        self._validate_api_key()
+        self._validate_audio_file(audio_file)
+
+        response_format = kwargs.get("response_format", self.response_format)
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        data = {"response_format": response_format}
+
+        language = self._normalize_language(kwargs.get("language"))
+        if language:
+            data["language"] = language
+
+        prompt = kwargs.get("prompt")
+        if prompt:
+            data["prompt"] = prompt
+
+        if os.getenv("LEMONFOX_SPEAKER_LABELS", "").lower() in {"1", "true", "yes"}:
+            data["speaker_labels"] = "true"
+            if response_format != "verbose_json":
+                data["response_format"] = "verbose_json"
+                response_format = "verbose_json"
+
+        if os.getenv("LEMONFOX_TRANSLATE", "").lower() in {"1", "true", "yes"}:
+            data["translate"] = "true"
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                data=data,
+                files={"file": f},
+                timeout=120,
+            )
+
+        if response.status_code != 200:
+            raise Exception(
+                f"Lemonfox transcription failed ({response.status_code}): {response.text}"
+            )
+
+        if response_format in ["json", "verbose_json"]:
+            return response.json()
+        return response.text
+
+    def _validate_api_key(self):
+        if not self.api_key:
+            raise ValueError("LEMONFOX_API_KEY is required to use the Lemonfox API.")
+
+    def _validate_audio_file(self, audio_file: str):
+        if not os.path.exists(audio_file):
+            raise ValueError(f"File {audio_file} does not exist.")
+
+        file_size_mb = os.path.getsize(audio_file) / (1024 * 1024)
+        if file_size_mb > self.max_file_size_mb:
+            raise Exception(
+                f"File size exceeds the maximum limit of {self.max_file_size_mb} MB."
+            )
+
+        valid_extensions = [
+            ".mp3",
+            ".wav",
+            ".flac",
+            ".aac",
+            ".opus",
+            ".ogg",
+            ".m4a",
+            ".mp4",
+            ".mpeg",
+            ".mov",
+            ".webm",
+        ]
+        if not any(str(audio_file).lower().endswith(ext) for ext in valid_extensions):
+            raise ValueError(
+                f"Unsupported audio file format: {audio_file}. "
+                f"Supported formats are {valid_extensions}."
+            )
+
+    def _normalize_language(self, language):
+        if not language:
+            return None
+        return self.LANGUAGE_ALIASES.get(str(language).lower(), language)

--- a/tests/test_lemonfox.py
+++ b/tests/test_lemonfox.py
@@ -1,0 +1,100 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sapat.transcription.lemonfox import LemonfoxTranscription
+
+
+class LemonfoxTranscriptionTest(unittest.TestCase):
+    def setUp(self):
+        self.env = {
+            "LEMONFOX_API_KEY": "test-key",
+            "LEMONFOX_API_ENDPOINT": "https://api.lemonfox.ai/v1/audio/transcriptions",
+        }
+
+    def _audio_file(self, suffix=".mp3"):
+        handle = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        handle.write(b"fake audio")
+        handle.close()
+        self.addCleanup(lambda: os.path.exists(handle.name) and os.unlink(handle.name))
+        return handle.name
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_requires_api_key(self):
+        transcriber = LemonfoxTranscription(temperature=0.3)
+        with self.assertRaisesRegex(ValueError, "LEMONFOX_API_KEY"):
+            transcriber.transcribe_audio(self._audio_file())
+
+    @patch("sapat.transcription.lemonfox.requests.post")
+    def test_posts_audio_to_lemonfox(self, post):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"text": "hello world"}
+        post.return_value = response
+
+        with patch.dict(os.environ, self.env, clear=True):
+            transcriber = LemonfoxTranscription(temperature=0.3)
+            result = transcriber.transcribe_audio(
+                self._audio_file(),
+                language="en",
+                prompt="Daytona workspace",
+            )
+
+        self.assertEqual(result, {"text": "hello world"})
+        _, kwargs = post.call_args
+        self.assertEqual(
+            kwargs["headers"]["Authorization"],
+            "Bearer test-key",
+        )
+        self.assertEqual(kwargs["data"]["response_format"], "json")
+        self.assertEqual(kwargs["data"]["language"], "english")
+        self.assertEqual(kwargs["data"]["prompt"], "Daytona workspace")
+        self.assertIn("file", kwargs["files"])
+        self.assertEqual(kwargs["timeout"], 120)
+
+    @patch("sapat.transcription.lemonfox.requests.post")
+    def test_speaker_labels_switch_json_to_verbose_json(self, post):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"text": "hello", "segments": []}
+        post.return_value = response
+
+        env = {
+            **self.env,
+            "LEMONFOX_SPEAKER_LABELS": "true",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            transcriber = LemonfoxTranscription(temperature=0.3)
+            transcriber.transcribe_audio(self._audio_file())
+
+        _, kwargs = post.call_args
+        self.assertEqual(kwargs["data"]["speaker_labels"], "true")
+        self.assertEqual(kwargs["data"]["response_format"], "verbose_json")
+
+    @patch("sapat.transcription.lemonfox.requests.post")
+    def test_text_response_format_returns_body_text(self, post):
+        response = MagicMock()
+        response.status_code = 200
+        response.text = "plain transcript"
+        post.return_value = response
+
+        env = {
+            **self.env,
+            "LEMONFOX_RESPONSE_FORMAT": "text",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            transcriber = LemonfoxTranscription(temperature=0.3)
+            result = transcriber.transcribe_audio(self._audio_file())
+
+        self.assertEqual(result, "plain transcript")
+
+    def test_rejects_unsupported_audio_extension(self):
+        with patch.dict(os.environ, self.env, clear=True):
+            transcriber = LemonfoxTranscription(temperature=0.3)
+            with self.assertRaisesRegex(ValueError, "Unsupported audio file format"):
+                transcriber.transcribe_audio(self._audio_file(".txt"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Lemonfox transcription provider using the documented OpenAI-compatible `/v1/audio/transcriptions` endpoint
- expose `--api lemonfox` in the CLI and document Lemonfox environment variables
- add mocked unit tests for request construction, missing API key handling, speaker-label mode, text responses, and file validation

## Validation
- `.venv/bin/python -m unittest discover -s tests -v`
- `.venv/bin/python -m compileall src tests`
- `.venv/bin/sapat --help | rg -n 'lemonfox|openai|groq|azure'`\n- `git diff --check`\n\nCompanion Daytona content guide will link this provider PR. No secrets, media files, or generated transcripts are included.