### PR TITLE
Add Deepgram transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ AZURE_OPENAI_API_VERSION_CHAT=2023-03-15-preview
 # --- Groq ---
 GROQ_API_KEY=
 
+# --- Deepgram ---
+DEEPGRAM_API_KEY=
+# DEEPGRAM_API_ENDPOINT=https://api.deepgram.com/v1/listen
+# DEEPGRAM_MODEL=nova-3
+# DEEPGRAM_SMART_FORMAT=true
+# DEEPGRAM_DIARIZE=false
+# DEEPGRAM_PUNCTUATE=false
+
 # --- DeepInfra ---
 DEEPINFRA_API_KEY=
 

--- a/sapat/providers/deepgram.py
+++ b/sapat/providers/deepgram.py
@@ -1,0 +1,93 @@
+# ABOUTME: Deepgram transcription provider
+# ABOUTME: Uses Deepgram's pre-recorded Listen REST API
+
+import os
+from typing import Optional
+
+import requests
+
+from sapat.providers import register
+from sapat.providers.base import (
+    AudioFormat,
+    ProviderConfig,
+    TranscriptionProvider,
+    TranscriptionResult,
+)
+
+
+@register
+class DeepgramProvider(TranscriptionProvider):
+    name = "deepgram"
+    config = ProviderConfig(
+        required_env_vars=["DEEPGRAM_API_KEY"],
+        max_file_size_mb=2000.0,
+        preferred_format=AudioFormat.MP3,
+        supports_correction=False,
+        default_model=os.getenv("DEEPGRAM_MODEL", "nova-3"),
+    )
+
+    def resolve_model(self, model_alias: str) -> str:
+        aliases = {
+            "default": "nova-3",
+            "nova": "nova-3",
+            "enhanced": "enhanced",
+            "base": "base",
+        }
+        return aliases.get(model_alias, model_alias)
+
+    def transcribe(
+        self,
+        audio_file: str,
+        model: str,
+        language: str = "en",
+        prompt: Optional[str] = None,
+        temperature: float = 0,
+        **kwargs,
+    ) -> TranscriptionResult:
+        endpoint = os.getenv(
+            "DEEPGRAM_API_ENDPOINT",
+            "https://api.deepgram.com/v1/listen",
+        )
+        params = {
+            "model": model,
+            "language": language,
+            "smart_format": os.getenv("DEEPGRAM_SMART_FORMAT", "true"),
+        }
+
+        if os.getenv("DEEPGRAM_DIARIZE", "").lower() in {"1", "true", "yes"}:
+            params["diarize"] = "true"
+        if os.getenv("DEEPGRAM_PUNCTUATE", "").lower() in {"1", "true", "yes"}:
+            params["punctuate"] = "true"
+        if prompt:
+            params["keywords"] = prompt
+
+        headers = {
+            "Authorization": f"Token {os.getenv('DEEPGRAM_API_KEY', '')}",
+            "Content-Type": "audio/mpeg",
+        }
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                endpoint,
+                headers=headers,
+                params=params,
+                data=f.read(),
+            )
+
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Deepgram transcription failed ({response.status_code}): "
+                f"{response.text}"
+            )
+
+        payload = response.json()
+        text = self._extract_transcript(payload)
+        return TranscriptionResult(text=text, raw_response=payload)
+
+    @staticmethod
+    def _extract_transcript(payload: dict) -> str:
+        try:
+            alternatives = payload["results"]["channels"][0]["alternatives"]
+            return alternatives[0].get("transcript", "")
+        except (KeyError, IndexError, TypeError):
+            return ""

--- a/tests/providers/test_group_a.py
+++ b/tests/providers/test_group_a.py
@@ -1,4 +1,4 @@
-# ABOUTME: Mock-based tests for all 8 transcription providers in group A
+# ABOUTME: Mock-based tests for transcription providers in group A
 # ABOUTME: Tests verify each provider sends correct auth, URL, and payload
 
 import os
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sapat.providers.base import TranscriptionResult
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -56,7 +55,10 @@ class TestDeepInfraProvider:
 
         _, kwargs = mock_post.call_args
         assert kwargs["headers"]["Authorization"] == "Bearer test-key"
-        assert mock_post.call_args.args[0] == "https://api.deepinfra.com/v1/openai/audio/transcriptions"
+        assert (
+            mock_post.call_args.args[0]
+            == "https://api.deepinfra.com/v1/openai/audio/transcriptions"
+        )
         assert kwargs["data"]["model"] == "openai/whisper-large-v3"
         assert "file" in kwargs["files"]
 
@@ -105,7 +107,10 @@ class TestVeniceProvider:
 
         _, kwargs = mock_post.call_args
         assert kwargs["headers"]["Authorization"] == "Bearer test-key"
-        assert mock_post.call_args.args[0] == "https://api.venice.ai/api/v1/audio/transcriptions"
+        assert (
+            mock_post.call_args.args[0]
+            == "https://api.venice.ai/api/v1/audio/transcriptions"
+        )
         assert kwargs["data"]["model"] == "whisper-large-v3"
         assert "file" in kwargs["files"]
 
@@ -143,7 +148,10 @@ class TestTogetherProvider:
 
         _, kwargs = mock_post.call_args
         assert kwargs["headers"]["Authorization"] == "Bearer test-key"
-        assert mock_post.call_args.args[0] == "https://api.together.xyz/v1/audio/transcriptions"
+        assert (
+            mock_post.call_args.args[0]
+            == "https://api.together.xyz/v1/audio/transcriptions"
+        )
         assert kwargs["data"]["model"] == "openai/whisper-large-v3"
         assert "file" in kwargs["files"]
 
@@ -219,7 +227,10 @@ class TestMistralProvider:
 
         _, kwargs = mock_post.call_args
         assert kwargs["headers"]["Authorization"] == "Bearer test-key"
-        assert mock_post.call_args.args[0] == "https://api.mistral.ai/v1/audio/transcriptions"
+        assert (
+            mock_post.call_args.args[0]
+            == "https://api.mistral.ai/v1/audio/transcriptions"
+        )
         assert kwargs["data"]["model"] == "voxtral-mini-latest"
         # Mistral uses context_bias instead of prompt
         assert "prompt" not in kwargs["data"]
@@ -233,7 +244,9 @@ class TestMistralProvider:
         from sapat.providers.mistral import MistralProvider
 
         provider = MistralProvider()
-        provider.transcribe(audio_file, model="voxtral-mini-latest", prompt="Product: Sapat")
+        provider.transcribe(
+            audio_file, model="voxtral-mini-latest", prompt="Product: Sapat"
+        )
 
         _, kwargs = mock_post.call_args
         assert kwargs["data"]["context_bias"] == "Product: Sapat"
@@ -241,9 +254,9 @@ class TestMistralProvider:
     @patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}, clear=False)
     @patch("sapat.providers.mistral.requests.post")
     def test_correct_transcript_uses_chat_endpoint(self, mock_post):
-        chat_response = FakeResponse(payload={
-            "choices": [{"message": {"content": "corrected text"}}]
-        })
+        chat_response = FakeResponse(
+            payload={"choices": [{"message": {"content": "corrected text"}}]}
+        )
         mock_post.return_value = chat_response
 
         from sapat.providers.mistral import MistralProvider
@@ -253,7 +266,9 @@ class TestMistralProvider:
 
         assert result == "corrected text"
         _, kwargs = mock_post.call_args
-        assert mock_post.call_args.args[0] == "https://api.mistral.ai/v1/chat/completions"
+        assert (
+            mock_post.call_args.args[0] == "https://api.mistral.ai/v1/chat/completions"
+        )
         assert kwargs["json"]["messages"][1]["content"] == "raw text"
 
     @patch.dict(os.environ, {"MISTRAL_API_KEY": "test-key"}, clear=False)
@@ -296,7 +311,10 @@ class TestLemonfoxProvider:
 
         _, kwargs = mock_post.call_args
         assert kwargs["headers"]["Authorization"] == "Bearer test-key"
-        assert mock_post.call_args.args[0] == "https://api.lemonfox.ai/v1/audio/transcriptions"
+        assert (
+            mock_post.call_args.args[0]
+            == "https://api.lemonfox.ai/v1/audio/transcriptions"
+        )
         assert kwargs["data"]["model"] == "whisper-1"
         assert "file" in kwargs["files"]
 
@@ -339,7 +357,10 @@ class TestLocalAIProvider:
         _, kwargs = mock_post.call_args
         # No auth header when LOCALAI_API_KEY is not set
         assert "Authorization" not in kwargs["headers"]
-        assert mock_post.call_args.args[0] == "http://localhost:8080/v1/audio/transcriptions"
+        assert (
+            mock_post.call_args.args[0]
+            == "http://localhost:8080/v1/audio/transcriptions"
+        )
         assert kwargs["data"]["model"] == "whisper-1"
         assert "file" in kwargs["files"]
 
@@ -404,7 +425,9 @@ class TestElevenLabsProvider:
         assert "xi-api-key" in kwargs["headers"]
         assert kwargs["headers"]["xi-api-key"] == "test-key"
         assert "Authorization" not in kwargs["headers"]
-        assert mock_post.call_args.args[0] == "https://api.elevenlabs.io/v1/speech-to-text"
+        assert (
+            mock_post.call_args.args[0] == "https://api.elevenlabs.io/v1/speech-to-text"
+        )
         # ElevenLabs uses model_id, not model
         assert kwargs["data"]["model_id"] == "scribe_v2"
         assert "file" in kwargs["files"]
@@ -445,3 +468,102 @@ class TestElevenLabsProvider:
         provider = ElevenLabsProvider()
         with pytest.raises(RuntimeError, match="401"):
             provider.transcribe(audio_file, model="scribe_v2")
+
+
+# ===========================================================================
+# 9. Deepgram
+# ===========================================================================
+
+
+class TestDeepgramProvider:
+    @patch.dict(os.environ, {"DEEPGRAM_API_KEY": "test-key"}, clear=True)
+    def test_is_available(self):
+        from sapat.providers.deepgram import DeepgramProvider
+
+        assert DeepgramProvider.is_available() is True
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_is_not_available_without_key(self):
+        from sapat.providers.deepgram import DeepgramProvider
+
+        assert DeepgramProvider.is_available() is False
+
+    @patch.dict(os.environ, {"DEEPGRAM_API_KEY": "test-key"}, clear=True)
+    def test_resolve_model_aliases(self):
+        from sapat.providers.deepgram import DeepgramProvider
+
+        provider = DeepgramProvider()
+        assert provider.resolve_model("default") == "nova-3"
+        assert provider.resolve_model("nova") == "nova-3"
+        assert provider.resolve_model("custom-model") == "custom-model"
+
+    @patch.dict(
+        os.environ,
+        {
+            "DEEPGRAM_API_KEY": "test-key",
+            "DEEPGRAM_API_ENDPOINT": "https://example.test/v1/listen",
+            "DEEPGRAM_DIARIZE": "true",
+            "DEEPGRAM_PUNCTUATE": "1",
+        },
+        clear=True,
+    )
+    @patch("sapat.providers.deepgram.requests.post")
+    def test_transcribe_posts_binary_audio_to_listen_endpoint(
+        self, mock_post, audio_file
+    ):
+        mock_post.return_value = FakeResponse(
+            payload={
+                "results": {
+                    "channels": [
+                        {"alternatives": [{"transcript": "hello from deepgram"}]}
+                    ]
+                }
+            }
+        )
+
+        from sapat.providers.deepgram import DeepgramProvider
+
+        provider = DeepgramProvider()
+        result = provider.transcribe(
+            audio_file,
+            model="nova-3",
+            language="en",
+            prompt="Sapat, Daytona",
+        )
+
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "hello from deepgram"
+
+        call_args = mock_post.call_args
+        assert call_args.args[0] == "https://example.test/v1/listen"
+        kwargs = call_args.kwargs
+        assert kwargs["headers"]["Authorization"] == "Token test-key"
+        assert kwargs["headers"]["Content-Type"] == "audio/mpeg"
+        assert kwargs["params"] == {
+            "model": "nova-3",
+            "language": "en",
+            "smart_format": "true",
+            "diarize": "true",
+            "punctuate": "true",
+            "keywords": "Sapat, Daytona",
+        }
+        assert kwargs["data"] == b"fake audio data"
+
+    @patch.dict(os.environ, {"DEEPGRAM_API_KEY": "test-key"}, clear=True)
+    @patch("sapat.providers.deepgram.requests.post")
+    def test_transcribe_error_raises(self, mock_post, audio_file):
+        mock_post.return_value = FakeResponse(
+            status_code=401,
+            text="bad token",
+        )
+
+        from sapat.providers.deepgram import DeepgramProvider
+
+        provider = DeepgramProvider()
+        with pytest.raises(RuntimeError, match="Deepgram transcription failed"):
+            provider.transcribe(audio_file, model="nova-3")
+
+    def test_extract_transcript_returns_empty_for_unexpected_payload(self):
+        from sapat.providers.deepgram import DeepgramProvider
+
+        assert DeepgramProvider._extract_transcript({}) == ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,20 +17,38 @@ class MockProvider(TranscriptionProvider):
     name = "mock"
     config = ProviderConfig(default_model="mock-model")
 
-    def transcribe(self, audio_file, model, language="en", prompt=None, temperature=0, **kwargs):
+    def transcribe(
+        self, audio_file, model, language="en", prompt=None, temperature=0, **kwargs
+    ):
         return TranscriptionResult(text="mocked transcription")
+
+
+class MockDeepgramProvider(TranscriptionProvider):
+    name = "deepgram"
+    config = ProviderConfig(default_model="nova-3")
+
+    def resolve_model(self, model_alias: str) -> str:
+        return "nova-3" if model_alias in {"default", "nova"} else model_alias
+
+    def transcribe(
+        self, audio_file, model, language="en", prompt=None, temperature=0, **kwargs
+    ):
+        return TranscriptionResult(text="deepgram transcription")
 
 
 @pytest.fixture(autouse=True)
 def mock_registry(monkeypatch):
     """Replace the registry with a single mock provider."""
     import sapat.providers as reg
+
     reg._registry.clear()
     reg._discovered = True
     reg._registry["mock"] = MockProvider
 
     monkeypatch.setattr("sapat.providers._discover_providers", lambda: None)
-    monkeypatch.setattr("sapat.providers.get_available_providers", lambda: {"mock": MockProvider})
+    monkeypatch.setattr(
+        "sapat.providers.get_available_providers", lambda: {"mock": MockProvider}
+    )
 
     yield
 
@@ -41,6 +59,7 @@ def mock_registry(monkeypatch):
 class TestCLI:
     def test_help_shows_provider_option(self):
         from sapat.cli import main
+
         runner = CliRunner()
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == 0
@@ -48,14 +67,49 @@ class TestCLI:
 
     def test_version_flag(self):
         from sapat.cli import main
+
         runner = CliRunner()
         result = runner.invoke(main, ["--version"])
         assert "0.3.0" in result.output
 
     def test_no_providers_available_error(self, monkeypatch):
         from sapat.cli import main
+
         monkeypatch.setattr("sapat.providers.get_available_providers", lambda: {})
         runner = CliRunner()
         result = runner.invoke(main, ["--help"])
         # Should not crash at help time, but invocation would fail
         assert result.exit_code == 0
+
+    def test_invokes_deepgram_provider_with_resolved_model(self, monkeypatch, tmp_path):
+        from sapat.cli import main
+
+        media = tmp_path / "demo.mp4"
+        media.write_bytes(b"fake media")
+        process_file = MagicMock()
+        monkeypatch.setattr(
+            "sapat.cli.get_available_providers",
+            lambda: {"deepgram": MockDeepgramProvider},
+        )
+        monkeypatch.setattr("sapat.cli.process_file", process_file)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                str(media),
+                "--provider",
+                "deepgram",
+                "--model",
+                "nova",
+                "--language",
+                "en",
+                "--quality",
+                "H",
+            ],
+        )
+
+        assert result.exit_code == 0
+        process_file.assert_called_once()
+        assert process_file.call_args.args[1].name == "deepgram"
+        assert process_file.call_args.args[2] == "nova-3"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -24,7 +24,9 @@ class FakeProvider(TranscriptionProvider):
     name = "fake_test"
     config = ProviderConfig(required_env_vars=[])
 
-    def transcribe(self, audio_file, model, language="en", prompt=None, temperature=0, **kwargs):
+    def transcribe(
+        self, audio_file, model, language="en", prompt=None, temperature=0, **kwargs
+    ):
         return TranscriptionResult(text="fake")
 
 
@@ -32,6 +34,7 @@ class FakeProvider(TranscriptionProvider):
 def reset_registry():
     """Reset the registry before each test."""
     import sapat.providers as reg
+
     reg._registry.clear()
     reg._discovered = False
     yield
@@ -92,20 +95,32 @@ class TestGetProviderChoices:
 
 class TestAutoDiscovery:
     def test_discovers_azure_when_env_set(self):
-        with patch.dict(os.environ, {
-            "AZURE_OPENAI_API_KEY": "test",
-            "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com",
-            "AZURE_OPENAI_STT_API_VERSION": "2024-02-01",
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "AZURE_OPENAI_API_KEY": "test",
+                "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com",
+                "AZURE_OPENAI_STT_API_VERSION": "2024-02-01",
+            },
+        ):
             from sapat.providers.azure import AzureProvider
+
             register(AzureProvider)
             assert "azure" in _registry
 
     def test_discovers_groq_when_env_set(self):
         with patch.dict(os.environ, {"GROQ_API_KEY": "test"}):
             from sapat.providers.groq import GroqProvider
+
             register(GroqProvider)
             assert "groq" in _registry
+
+    def test_discovers_deepgram_when_env_set(self):
+        with patch.dict(os.environ, {"DEEPGRAM_API_KEY": "test"}):
+            from sapat.providers.deepgram import DeepgramProvider
+
+            register(DeepgramProvider)
+            assert "deepgram" in _registry
 
     def test_no_discovery_without_env(self):
         with patch.dict(os.environ, {}, clear=True):


### PR DESCRIPTION
## Summary
- add a Deepgram transcription provider for Sapat's current provider registry
- support DEEPGRAM_API_KEY plus endpoint/model/format/diarization/punctuation env flags
- add mocked request/response coverage and document the Deepgram env block

## Validation
- `python -m compileall sapat tests`
- `python -m pytest tests/providers/test_group_a.py tests/test_registry.py tests/test_cli.py -q` (50 passed)
- `python -m black --check sapat/providers/deepgram.py tests/providers/test_group_a.py`
- `git diff --check`
- Full `python -m pytest tests -q` currently reports 181 passed and 1 unrelated Windows path failure in `tests/providers/test_group_d.py::TestWhisperXProvider::test_transcribe_builds_command_and_reads_output` because `WHISPERX_BINARY` loses path separators before validation.

No secrets, audio files, generated transcripts, or payout details are included.