### PR TITLE
Add Deepgram transcription provider

### DIFF
--- a/sapat/providers/deepgram.py
+++ b/sapat/providers/deepgram.py
@@ -1,0 +1,73 @@
+# ABOUTME: Deepgram transcription provider
+# ABOUTME: Uses Deepgram's pre-recorded audio transcription endpoint
+
+import os
+from typing import Optional
+
+import requests
+
+from sapat.providers import register
+from sapat.providers.base import ProviderConfig, TranscriptionProvider, TranscriptionResult
+
+
+@register
+class DeepgramProvider(TranscriptionProvider):
+    """Deepgram pre-recorded transcription provider."""
+
+    name = "deepgram"
+    config = ProviderConfig(
+        required_env_vars=["DEEPGRAM_API_KEY"],
+        default_model="nova-3",
+    )
+
+    def __init__(self):
+        super().__init__()
+        self.api_key = os.getenv("DEEPGRAM_API_KEY", "")
+        self.endpoint = os.getenv(
+            "DEEPGRAM_API_ENDPOINT",
+            "https://api.deepgram.com/v1/listen",
+        )
+
+    def transcribe(
+        self,
+        audio_file: str,
+        model: str,
+        language: str = "en",
+        prompt: Optional[str] = None,
+        temperature: float = 0,
+        **kwargs,
+    ) -> TranscriptionResult:
+        params = {
+            "model": model,
+            "smart_format": "true",
+        }
+        if language:
+            params["language"] = language
+
+        headers = {"Authorization": f"Token {self.api_key}"}
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                self.endpoint,
+                headers=headers,
+                params=params,
+                data=f,
+                timeout=120,
+            )
+
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Deepgram transcription failed ({response.status_code}): {response.text}"
+            )
+
+        payload = response.json()
+        alternative = (
+            payload.get("results", {})
+            .get("channels", [{}])[0]
+            .get("alternatives", [{}])[0]
+        )
+        return TranscriptionResult(
+            text=alternative.get("transcript", ""),
+            language=payload.get("metadata", {}).get("language"),
+            raw_response=payload,
+        )

--- a/tests/providers/test_deepgram.py
+++ b/tests/providers/test_deepgram.py
@@ -1,0 +1,87 @@
+# ABOUTME: Mocked Deepgram provider tests
+# ABOUTME: Verifies auth, request parameters, availability, and response parsing
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from sapat.providers.base import TranscriptionResult
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self.payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self.payload
+
+
+@pytest.fixture
+def audio_file(tmp_path):
+    path = tmp_path / "sample.mp3"
+    path.write_bytes(b"fake audio")
+    return str(path)
+
+
+class TestDeepgramProvider:
+    @patch.dict(os.environ, {"DEEPGRAM_API_KEY": "dg-test-key"}, clear=False)
+    @patch("sapat.providers.deepgram.requests.post")
+    def test_transcribe_sends_token_auth_and_parses_transcript(self, mock_post, audio_file):
+        mock_post.return_value = FakeResponse(
+            payload={
+                "metadata": {"language": "en"},
+                "results": {
+                    "channels": [
+                        {"alternatives": [{"transcript": "Hello from Deepgram."}]}
+                    ]
+                },
+            }
+        )
+
+        from sapat.providers.deepgram import DeepgramProvider
+
+        provider = DeepgramProvider()
+        result = provider.transcribe(audio_file, model="nova-3", language="en")
+
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "Hello from Deepgram."
+        assert result.language == "en"
+
+        call = mock_post.call_args.kwargs
+        assert call["headers"] == {"Authorization": "Token dg-test-key"}
+        assert call["params"]["model"] == "nova-3"
+        assert call["params"]["language"] == "en"
+        assert call["params"]["smart_format"] == "true"
+        assert call["timeout"] == 120
+
+    @patch.dict(os.environ, {"DEEPGRAM_API_KEY": "dg-test-key"}, clear=False)
+    def test_available_with_key(self):
+        from sapat.providers.deepgram import DeepgramProvider
+
+        assert DeepgramProvider.is_available() is True
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_not_available_without_key(self):
+        from sapat.providers.deepgram import DeepgramProvider
+
+        assert DeepgramProvider.is_available() is False
+
+    @patch.dict(os.environ, {"DEEPGRAM_API_KEY": "dg-test-key"}, clear=False)
+    @patch("sapat.providers.deepgram.requests.post")
+    def test_non_200_response_raises(self, mock_post, audio_file):
+        mock_post.return_value = FakeResponse(status_code=401, text="unauthorized")
+
+        from sapat.providers.deepgram import DeepgramProvider
+
+        provider = DeepgramProvider()
+        with pytest.raises(RuntimeError, match="Deepgram transcription failed"):
+            provider.transcribe(audio_file, model="nova-3", language="en")
+
+    @patch.dict(os.environ, {"DEEPGRAM_API_KEY": "dg-test-key"}, clear=False)
+    def test_default_model(self):
+        from sapat.providers.deepgram import DeepgramProvider
+
+        assert DeepgramProvider.config.default_model == "nova-3"


### PR DESCRIPTION
## Summary
- add a Deepgram pre-recorded transcription provider using `POST /v1/listen`
- register it behind `DEEPGRAM_API_KEY` with `nova-3` as the default model
- add mocked tests for auth, request params, availability, response parsing, and error handling

## Validation
- Not run locally: GitHub clone/network access was failing in this environment, so this PR was prepared through the GitHub API. The tests are mock-based and do not require a real Deepgram key.