### PR TITLE
Add PocketSphinx transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,4 +101,12 @@ WHISPERX_BINARY=whisperx
 VOSK_MODEL_PATH=
 
 # --- Moonshine (local, no config needed) ---
+# --- PocketSphinx (local, optional custom model paths) ---
+# POCKETSPHINX_HMM=
+# POCKETSPHINX_LM=
+# POCKETSPHINX_DICT=
+# POCKETSPHINX_KEYPHRASE=
+# POCKETSPHINX_KWS=
+# POCKETSPHINX_KWS_THRESHOLD=
+
 # --- LocalAI base URL already listed above ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ whisperx = ["whisperx"]
 picovoice = ["pvleopard"]
 replicate = ["replicate"]
 falai = ["fal-client"]
+pocketsphinx = ["pocketsphinx>=5.0.0"]
 all = [
     "sapat[oracle]",
     "sapat[vosk]",
@@ -39,11 +40,12 @@ all = [
     "sapat[picovoice]",
     "sapat[replicate]",
     "sapat[falai]",
+    "sapat[pocketsphinx]",
 ]
 dev = ["pytest", "pytest-mock", "black", "isort"]
 
 [tool.setuptools.packages.find]
-include = ["sapat"]
+include = ["sapat", "sapat.*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "sapat.__version__.__version__"}

--- a/sapat/process.py
+++ b/sapat/process.py
@@ -32,27 +32,42 @@ def process_file(
     ext = fmt.value
     converted_file = input_path.with_suffix(f".{ext}")
     txt_file = input_path.with_suffix(".txt")
+    converted_created = False
+    input_is_converted_file = input_path.resolve() == converted_file.resolve()
 
     click.echo(click.style(f"\nProcessing: {input_file}", fg="cyan", bold=True))
 
     # Convert to provider-preferred format
-    if not converted_file.exists():
+    if input_is_converted_file:
+        click.echo(
+            click.style(f"Input is already {ext.upper()}, skipping", fg="yellow")
+        )
+    elif not converted_file.exists():
         with spinner_context(f"Converting to {ext.upper()}...") as spinner:
             try:
                 convert_audio(str(input_path), str(converted_file), quality, fmt)
+                converted_created = True
                 spinner.succeed(f"Conversion to {ext.upper()} completed")
             except Exception as e:
                 spinner.fail(f"Conversion failed: {e}")
                 return
     else:
-        click.echo(click.style(f"{ext.upper()} file already exists, skipping", fg="yellow"))
+        click.echo(
+            click.style(f"{ext.upper()} file already exists, skipping", fg="yellow")
+        )
 
     # Transcribe (with splitting if needed)
     max_size = provider.config.max_file_size_mb
     if should_split_file(str(converted_file), max_size_mb=max_size):
-        click.echo(click.style(f"File is large (>{max_size}MB), splitting into chunks...", fg="yellow"))
+        click.echo(
+            click.style(
+                f"File is large (>{max_size}MB), splitting into chunks...", fg="yellow"
+            )
+        )
         try:
-            result = _process_large_audio(str(converted_file), provider, model, language, prompt, temperature)
+            result = _process_large_audio(
+                str(converted_file), provider, model, language, prompt, temperature
+            )
         except Exception as e:
             click.echo(click.style(f"Error processing large file: {e}", fg="red"))
             return
@@ -87,8 +102,11 @@ def process_file(
     click.echo(click.style(f"Transcription saved to: {txt_file}", fg="green"))
 
     # Cleanup
-    converted_file.unlink()
-    click.echo(click.style("Temporary audio file removed", fg="yellow"))
+    if converted_created:
+        converted_file.unlink()
+        click.echo(click.style("Temporary audio file removed", fg="yellow"))
+    elif input_is_converted_file:
+        click.echo(click.style("Original audio file preserved", fg="yellow"))
 
 
 def _process_large_audio(
@@ -119,10 +137,13 @@ def _process_large_audio(
                     )
                     all_texts.append(result.text.strip())
                 except Exception as e:
-                    click.echo(click.style(f"Warning: chunk {i+1} failed: {e}", fg="yellow"))
+                    click.echo(
+                        click.style(f"Warning: chunk {i+1} failed: {e}", fg="yellow")
+                    )
                     all_texts.append(f"[Chunk {i+1} transcription failed]")
 
         from sapat.providers.base import TranscriptionResult
+
         return TranscriptionResult(text=" ".join(all_texts))
 
     finally:

--- a/sapat/providers/pocketsphinx.py
+++ b/sapat/providers/pocketsphinx.py
@@ -1,0 +1,139 @@
+# ABOUTME: PocketSphinx offline transcription provider
+# ABOUTME: Uses the pocketsphinx Python bindings for local WAV recognition
+
+import os
+import wave
+from pathlib import Path
+from typing import Optional
+
+from sapat.providers import register
+from sapat.providers.base import (
+    AudioFormat,
+    ProviderConfig,
+    TranscriptionProvider,
+    TranscriptionResult,
+)
+
+
+@register
+class PocketSphinxProvider(TranscriptionProvider):
+    name = "pocketsphinx"
+    config = ProviderConfig(
+        required_env_vars=[],
+        required_packages=["pocketsphinx"],
+        extras_key="pocketsphinx",
+        max_file_size_mb=float("inf"),
+        preferred_format=AudioFormat.WAV,
+        supports_correction=False,
+        default_model="default",
+    )
+
+    def transcribe(
+        self,
+        audio_file: str,
+        model: str,
+        language: str = "en",
+        prompt: Optional[str] = None,
+        temperature: float = 0,
+        **kwargs,
+    ) -> TranscriptionResult:
+        try:
+            from pocketsphinx import Pocketsphinx, Segmenter
+        except ImportError as exc:
+            raise ImportError(
+                "PocketSphinx support requires the optional pocketsphinx package. "
+                "Install it with `pip install 'sapat[pocketsphinx]'` or "
+                "`pip install pocketsphinx`."
+            ) from exc
+
+        options = self._build_recognizer_options(audio_file, model, **kwargs)
+        recognizer = Pocketsphinx(**options)
+
+        transcript_parts = []
+        with wave.open(audio_file, "rb") as audio:
+            self._validate_wav(audio_file, audio)
+            segmenter = Segmenter(sample_rate=audio.getframerate())
+            for segment in segmenter.segment(audio.getfp()):
+                recognizer.start_utt()
+                recognizer.process_raw(segment.pcm, full_utt=True)
+                recognizer.end_utt()
+
+                if options.get("keyphrase") and recognizer.hyp() is None:
+                    continue
+
+                text = recognizer.hypothesis()
+                if text:
+                    transcript_parts.append(text)
+
+        return TranscriptionResult(
+            text=" ".join(transcript_parts).strip(),
+            language=language,
+        )
+
+    def _build_recognizer_options(self, audio_file: str, model: str, **kwargs):
+        path = Path(audio_file)
+        if not path.is_file():
+            raise ValueError(f"Audio file not found: {audio_file}")
+
+        options = {}
+
+        hmm = kwargs.get("hmm") or os.getenv("POCKETSPHINX_HMM")
+        lm = kwargs.get("lm") or os.getenv("POCKETSPHINX_LM")
+        dictionary = kwargs.get("dictionary") or os.getenv("POCKETSPHINX_DICT")
+        keyphrase = kwargs.get("keyphrase") or os.getenv("POCKETSPHINX_KEYPHRASE")
+        keywords = kwargs.get("kws") or os.getenv("POCKETSPHINX_KWS")
+        threshold = kwargs.get("kws_threshold") or os.getenv(
+            "POCKETSPHINX_KWS_THRESHOLD"
+        )
+
+        keyword_search = bool(keyphrase or keywords)
+        if keyword_search:
+            options["lm"] = False
+
+        if (
+            model
+            and model != self.config.default_model
+            and not lm
+            and not keyword_search
+        ):
+            lm = model
+
+        self._add_existing_path(options, "hmm", hmm)
+        self._add_existing_path(options, "lm", lm)
+        self._add_existing_path(options, "dict", dictionary)
+        self._add_existing_path(options, "kws", keywords)
+
+        if keyphrase:
+            options["keyphrase"] = keyphrase
+        if threshold:
+            try:
+                options["kws_threshold"] = float(threshold)
+            except ValueError as exc:
+                raise ValueError(
+                    "POCKETSPHINX_KWS_THRESHOLD must be a number."
+                ) from exc
+
+        return options
+
+    @staticmethod
+    def _validate_wav(audio_file: str, audio):
+        if audio.getnchannels() != 1:
+            raise ValueError(
+                f"PocketSphinx requires mono WAV input, got {audio.getnchannels()} "
+                f"channels in {audio_file}."
+            )
+        if audio.getsampwidth() != 2:
+            raise ValueError(
+                f"PocketSphinx requires 16-bit PCM WAV input, got "
+                f"{audio.getsampwidth() * 8}-bit samples in {audio_file}."
+            )
+
+    @staticmethod
+    def _add_existing_path(options: dict, option_name: str, value: Optional[str]):
+        if not value:
+            return
+
+        if not Path(value).exists():
+            raise ValueError(f"PocketSphinx {option_name} path not found: {value}")
+
+        options[option_name] = value

--- a/tests/providers/test_pocketsphinx.py
+++ b/tests/providers/test_pocketsphinx.py
@@ -1,0 +1,203 @@
+# ABOUTME: Tests for the PocketSphinx local transcription provider
+# ABOUTME: Uses fake pocketsphinx modules so no model downloads are required
+
+import sys
+import types
+import wave
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from sapat.providers.base import TranscriptionResult
+
+
+class TestPocketSphinxProvider:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        from sapat.providers.pocketsphinx import PocketSphinxProvider
+
+        self.provider_cls = PocketSphinxProvider
+
+    def test_config_values(self):
+        cfg = self.provider_cls.config
+        assert cfg.preferred_format.value == "wav"
+        assert cfg.supports_correction is False
+        assert cfg.default_model == "default"
+        assert cfg.max_file_size_mb == float("inf")
+        assert cfg.extras_key == "pocketsphinx"
+
+    def test_build_options_uses_custom_paths(self, tmp_path):
+        audio = tmp_path / "speech.wav"
+        hmm = tmp_path / "hmm"
+        lm = tmp_path / "language.lm"
+        dictionary = tmp_path / "words.dict"
+        kws = tmp_path / "keywords.list"
+        audio.write_bytes(b"audio")
+        hmm.mkdir()
+        lm.write_text("lm", encoding="utf-8")
+        dictionary.write_text("dict", encoding="utf-8")
+        kws.write_text("hello /1e-20/", encoding="utf-8")
+
+        env = {
+            "POCKETSPHINX_HMM": str(hmm),
+            "POCKETSPHINX_LM": str(lm),
+            "POCKETSPHINX_DICT": str(dictionary),
+            "POCKETSPHINX_KWS": str(kws),
+            "POCKETSPHINX_KWS_THRESHOLD": "1e-20",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            provider = self.provider_cls.__new__(self.provider_cls)
+            options = provider._build_recognizer_options(str(audio), "default")
+
+        assert options["hmm"] == str(hmm)
+        assert options["lm"] == str(lm)
+        assert options["dict"] == str(dictionary)
+        assert options["kws"] == str(kws)
+        assert options["kws_threshold"] == 1e-20
+
+    def test_model_argument_can_select_language_model(self, tmp_path):
+        audio = tmp_path / "speech.wav"
+        lm = tmp_path / "domain.lm"
+        audio.write_bytes(b"audio")
+        lm.write_text("lm", encoding="utf-8")
+
+        provider = self.provider_cls.__new__(self.provider_cls)
+        options = provider._build_recognizer_options(str(audio), str(lm))
+
+        assert options["lm"] == str(lm)
+
+    def test_missing_audio_file_raises(self):
+        provider = self.provider_cls.__new__(self.provider_cls)
+        with pytest.raises(ValueError, match="Audio file not found"):
+            provider._build_recognizer_options("/tmp/not-real.wav", "default")
+
+    def test_missing_custom_path_raises(self, tmp_path):
+        audio = tmp_path / "speech.wav"
+        audio.write_bytes(b"audio")
+
+        with patch.dict(
+            "os.environ", {"POCKETSPHINX_LM": "/tmp/not-real.lm"}, clear=True
+        ):
+            provider = self.provider_cls.__new__(self.provider_cls)
+            with pytest.raises(ValueError, match="lm path not found"):
+                provider._build_recognizer_options(str(audio), "default")
+
+    def test_invalid_threshold_raises(self, tmp_path):
+        audio = tmp_path / "speech.wav"
+        audio.write_bytes(b"audio")
+
+        with patch.dict(
+            "os.environ", {"POCKETSPHINX_KWS_THRESHOLD": "nope"}, clear=True
+        ):
+            provider = self.provider_cls.__new__(self.provider_cls)
+            with pytest.raises(ValueError, match="must be a number"):
+                provider._build_recognizer_options(str(audio), "default")
+
+    def test_keyword_mode_disables_language_model(self, tmp_path):
+        audio = tmp_path / "speech.wav"
+        audio.write_bytes(b"audio")
+
+        with patch.dict("os.environ", {"POCKETSPHINX_KEYPHRASE": "hello"}, clear=True):
+            provider = self.provider_cls.__new__(self.provider_cls)
+            options = provider._build_recognizer_options(str(audio), "default")
+
+        assert options["lm"] is False
+        assert options["keyphrase"] == "hello"
+
+    def test_transcribe_collects_phrases(self, tmp_path):
+        audio = tmp_path / "speech.wav"
+        with wave.open(str(audio), "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(16000)
+            wav.writeframes(b"\x00\x00" * 16000)
+
+        class FakeSegmenter:
+            last_sample_rate = None
+
+            def __init__(self, sample_rate):
+                self.sample_rate = sample_rate
+                FakeSegmenter.last_sample_rate = sample_rate
+
+            def segment(self, stream):
+                stream.read()
+                return iter(
+                    [
+                        types.SimpleNamespace(pcm=b"hello"),
+                        types.SimpleNamespace(pcm=b"world"),
+                    ]
+                )
+
+        class FakePocketsphinx:
+            last_options = None
+            processed = []
+
+            def __init__(self, **options):
+                FakePocketsphinx.last_options = options
+                self.current_text = ""
+
+            def start_utt(self):
+                self.current_text = ""
+
+            def process_raw(self, pcm, full_utt=False):
+                FakePocketsphinx.processed.append((pcm, full_utt))
+                self.current_text = pcm.decode("utf-8")
+
+            def end_utt(self):
+                pass
+
+            def hyp(self):
+                return self.current_text
+
+            def hypothesis(self):
+                return self.current_text
+
+        fake_module = types.SimpleNamespace(
+            Pocketsphinx=FakePocketsphinx,
+            Segmenter=FakeSegmenter,
+        )
+
+        with patch.dict(sys.modules, {"pocketsphinx": fake_module}):
+            provider = self.provider_cls.__new__(self.provider_cls)
+            result = provider.transcribe(str(audio), "default", language="en")
+
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "hello world"
+        assert result.language == "en"
+        assert FakeSegmenter.last_sample_rate == 16000
+        assert FakePocketsphinx.last_options == {}
+        assert FakePocketsphinx.processed == [(b"hello", True), (b"world", True)]
+
+    def test_validate_wav_rejects_non_mono(self, tmp_path):
+        audio = tmp_path / "stereo.wav"
+        with wave.open(str(audio), "wb") as wav:
+            wav.setnchannels(2)
+            wav.setsampwidth(2)
+            wav.setframerate(16000)
+            wav.writeframes(b"\x00\x00" * 16000)
+
+        with wave.open(str(audio), "rb") as wav:
+            with pytest.raises(ValueError, match="mono WAV"):
+                self.provider_cls._validate_wav(str(audio), wav)
+
+    def test_validate_wav_rejects_non_16_bit(self, tmp_path):
+        audio = tmp_path / "eight-bit.wav"
+        with wave.open(str(audio), "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(1)
+            wav.setframerate(16000)
+            wav.writeframes(b"\x00" * 16000)
+
+        with wave.open(str(audio), "rb") as wav:
+            with pytest.raises(ValueError, match="16-bit PCM"):
+                self.provider_cls._validate_wav(str(audio), wav)
+
+    def test_missing_dependency_raises_import_error(self, tmp_path):
+        audio = tmp_path / "speech.wav"
+        audio.write_bytes(b"audio")
+
+        with patch.dict(sys.modules, {"pocketsphinx": None}):
+            provider = self.provider_cls.__new__(self.provider_cls)
+            with pytest.raises(ImportError, match="sapat\\[pocketsphinx\\]"):
+                provider.transcribe(str(audio), "default")

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,64 @@
+# ABOUTME: Tests for the shared file processing pipeline
+# ABOUTME: Covers temporary conversion cleanup and original-file preservation
+
+from pathlib import Path
+from unittest.mock import patch
+
+from sapat.process import process_file
+from sapat.providers.base import (
+    AudioFormat,
+    ProviderConfig,
+    TranscriptionProvider,
+    TranscriptionResult,
+)
+
+
+class FakeWavProvider(TranscriptionProvider):
+    name = "fake_wav"
+    config = ProviderConfig(
+        preferred_format=AudioFormat.WAV,
+        max_file_size_mb=float("inf"),
+    )
+
+    def transcribe(
+        self, audio_file, model, language="en", prompt=None, temperature=0, **kwargs
+    ):
+        self.last_audio_file = audio_file
+        return TranscriptionResult(text="safe transcript")
+
+
+def test_process_file_preserves_original_when_already_preferred_format(tmp_path):
+    audio = tmp_path / "input.wav"
+    audio.write_bytes(b"original wav")
+    provider = FakeWavProvider()
+
+    with patch("sapat.process.should_split_file", return_value=False), patch(
+        "sapat.process.convert_audio"
+    ) as mock_convert:
+        process_file(str(audio), provider, "default", "en", None, 0, "L", False)
+
+    assert audio.exists()
+    assert audio.read_bytes() == b"original wav"
+    assert Path(provider.last_audio_file) == audio
+    assert audio.with_suffix(".txt").read_text(encoding="utf-8") == "safe transcript"
+    mock_convert.assert_not_called()
+
+
+def test_process_file_removes_only_created_converted_file(tmp_path):
+    source = tmp_path / "input.mp4"
+    source.write_bytes(b"video")
+    converted = tmp_path / "input.wav"
+    provider = FakeWavProvider()
+
+    def fake_convert(input_file, output_file, quality, target_format):
+        Path(output_file).write_bytes(b"converted wav")
+
+    with patch("sapat.process.should_split_file", return_value=False), patch(
+        "sapat.process.convert_audio", side_effect=fake_convert
+    ):
+        process_file(str(source), provider, "default", "en", None, 0, "L", False)
+
+    assert source.exists()
+    assert not converted.exists()
+    assert Path(provider.last_audio_file) == converted
+    assert source.with_suffix(".txt").read_text(encoding="utf-8") == "safe transcript"


### PR DESCRIPTION
## Summary

- add a PocketSphinx provider for fully offline speech recognition
- expose optional PocketSphinx acoustic-model, language-model, dictionary, and keyword-spotting configuration
- preserve an input file when it already matches the provider's preferred audio format
- add provider and audio-lifecycle tests, packaging support, and example environment variables

## Motivation

PocketSphinx gives Sapat users a credential-free transcription option that runs locally. This also supports a distinct offline-transcription guide for [daytona/content#13](https://github.com/daytona/content/issues/13).

## Validation

- `python -m pytest`: 189 passed
- `python -m black --check ...`: passed
- `python -m compileall sapat tests`: passed
- `git diff --check origin/main...HEAD`: passed
- package wheel build: passed; the wheel contains `sapat/providers/pocketsphinx.py`
- real 16 kHz, mono, 16-bit PCM WAV smoke test: passed

This contribution was developed with AI assistance and manually reviewed. No credentials, private media, or generated transcript data are included.
