### PR TITLE
feat: add SpeechBrain transcription provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,4 +101,9 @@ WHISPERX_BINARY=whisperx
 VOSK_MODEL_PATH=
 
 # --- Moonshine (local, no config needed) ---
+# --- SpeechBrain (local, no credentials needed) ---
+# SPEECHBRAIN_MODEL=speechbrain/asr-crdnn-rnnlm-librispeech
+# SPEECHBRAIN_SAVEDIR=pretrained_models/asr-crdnn-rnnlm-librispeech
+# SPEECHBRAIN_DEVICE=cpu
+
 # --- LocalAI base URL already listed above ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ whisperx = ["whisperx"]
 picovoice = ["pvleopard"]
 replicate = ["replicate"]
 falai = ["fal-client"]
+speechbrain = ["speechbrain"]
 all = [
     "sapat[oracle]",
     "sapat[vosk]",
@@ -39,6 +40,7 @@ all = [
     "sapat[picovoice]",
     "sapat[replicate]",
     "sapat[falai]",
+    "sapat[speechbrain]",
 ]
 dev = ["pytest", "pytest-mock", "black", "isort"]
 

--- a/sapat/providers/speechbrain.py
+++ b/sapat/providers/speechbrain.py
@@ -1,0 +1,103 @@
+# ABOUTME: SpeechBrain local transcription provider
+# ABOUTME: Uses the maintained SpeechBrain inference API for local ASR
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from sapat.providers import register
+from sapat.providers.base import (
+    AudioFormat,
+    ProviderConfig,
+    TranscriptionProvider,
+    TranscriptionResult,
+)
+
+
+@register
+class SpeechBrainProvider(TranscriptionProvider):
+    """Transcribe audio locally with a pretrained SpeechBrain ASR model."""
+
+    name = "speechbrain"
+    config = ProviderConfig(
+        required_env_vars=[],
+        required_packages=["speechbrain"],
+        extras_key="speechbrain",
+        max_file_size_mb=float("inf"),
+        preferred_format=AudioFormat.WAV,
+        supports_correction=False,
+        default_model="speechbrain/asr-crdnn-rnnlm-librispeech",
+    )
+
+    def transcribe(
+        self,
+        audio_file: str,
+        model: str,
+        language: str = "en",
+        prompt: Optional[str] = None,
+        temperature: float = 0,
+        **kwargs,
+    ) -> TranscriptionResult:
+        self._validate_audio_file(audio_file)
+
+        env_model = os.getenv("SPEECHBRAIN_MODEL")
+        source = model or self.config.default_model
+        if env_model and source == self.config.default_model:
+            source = env_model
+        savedir = os.getenv("SPEECHBRAIN_SAVEDIR")
+        device = os.getenv("SPEECHBRAIN_DEVICE", "cpu")
+
+        loader_kwargs = {
+            "source": source,
+            "run_opts": {"device": device},
+        }
+        if savedir:
+            loader_kwargs["savedir"] = savedir
+
+        try:
+            asr_class = self._get_asr_class()
+            recognizer = asr_class.from_hparams(**loader_kwargs)
+            raw_output = recognizer.transcribe_file(audio_file)
+            text = self._extract_text(raw_output)
+        except ImportError:
+            raise
+        except Exception as exc:
+            raise RuntimeError(f"SpeechBrain transcription failed: {exc}") from exc
+
+        return TranscriptionResult(text=text, raw_response=raw_output)
+
+    @staticmethod
+    def _get_asr_class():
+        try:
+            from speechbrain.inference.ASR import EncoderDecoderASR
+        except ImportError as exc:
+            raise ImportError(
+                "SpeechBrain support requires the optional speechbrain package. "
+                "Install it with `pip install 'sapat[speechbrain]'`."
+            ) from exc
+
+        return EncoderDecoderASR
+
+    @staticmethod
+    def _validate_audio_file(audio_file: str) -> None:
+        if not Path(audio_file).is_file():
+            raise ValueError(f"File {audio_file} does not exist.")
+
+    @classmethod
+    def _extract_text(cls, output: Any) -> str:
+        if isinstance(output, str):
+            return output.strip()
+
+        if isinstance(output, tuple):
+            if not output:
+                return ""
+            return cls._extract_text(output[0])
+
+        if isinstance(output, list):
+            parts = [cls._extract_text(part) for part in output]
+            return " ".join(part for part in parts if part).strip()
+
+        if output is None:
+            return ""
+
+        raise ValueError(f"Unsupported SpeechBrain transcription output: {output!r}")

--- a/tests/providers/test_speechbrain.py
+++ b/tests/providers/test_speechbrain.py
@@ -1,0 +1,194 @@
+# ABOUTME: Tests for the local SpeechBrain transcription provider
+# ABOUTME: Uses mocked inference classes so no models or dependencies are downloaded
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sapat.providers.base import TranscriptionResult
+from sapat.providers.speechbrain import SpeechBrainProvider
+
+
+class TestSpeechBrainProvider:
+    def test_config_values(self):
+        config = SpeechBrainProvider.config
+
+        assert config.required_env_vars == []
+        assert config.required_packages == ["speechbrain"]
+        assert config.extras_key == "speechbrain"
+        assert config.preferred_format.value == "wav"
+        assert config.default_model == "speechbrain/asr-crdnn-rnnlm-librispeech"
+
+    def test_is_available_with_mock_dependency(self):
+        fake_speechbrain = types.ModuleType("speechbrain")
+
+        with patch.dict(sys.modules, {"speechbrain": fake_speechbrain}):
+            assert SpeechBrainProvider.is_available() is True
+
+    def test_env_model_overrides_default_model(self, tmp_path):
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"wav")
+        recognizer = MagicMock()
+        recognizer.transcribe_file.return_value = "hello"
+        asr_class = MagicMock()
+        asr_class.from_hparams.return_value = recognizer
+
+        env = {"SPEECHBRAIN_MODEL": "org/model-from-env"}
+        with patch.dict("os.environ", env, clear=True):
+            with patch.object(
+                SpeechBrainProvider, "_get_asr_class", return_value=asr_class
+            ):
+                SpeechBrainProvider().transcribe(
+                    str(audio), model=SpeechBrainProvider.config.default_model
+                )
+
+        assert asr_class.from_hparams.call_args.kwargs["source"] == "org/model-from-env"
+
+    def test_explicit_non_default_model_beats_env_override(self, tmp_path):
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"wav")
+        recognizer = MagicMock()
+        recognizer.transcribe_file.return_value = "hello"
+        asr_class = MagicMock()
+        asr_class.from_hparams.return_value = recognizer
+
+        with patch.dict(
+            "os.environ", {"SPEECHBRAIN_MODEL": "org/env-model"}, clear=True
+        ):
+            with patch.object(
+                SpeechBrainProvider, "_get_asr_class", return_value=asr_class
+            ):
+                SpeechBrainProvider().transcribe(str(audio), model="org/explicit-model")
+
+        assert asr_class.from_hparams.call_args.kwargs["source"] == "org/explicit-model"
+
+    def test_model_argument_used_without_env_override(self, tmp_path):
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"wav")
+        recognizer = MagicMock()
+        recognizer.transcribe_file.return_value = "hello"
+        asr_class = MagicMock()
+        asr_class.from_hparams.return_value = recognizer
+
+        with patch.dict("os.environ", {}, clear=True):
+            with patch.object(
+                SpeechBrainProvider, "_get_asr_class", return_value=asr_class
+            ):
+                SpeechBrainProvider().transcribe(str(audio), model="org/explicit-model")
+
+        assert asr_class.from_hparams.call_args.kwargs["source"] == "org/explicit-model"
+
+    def test_from_hparams_receives_savedir_and_device(self, tmp_path):
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"wav")
+        recognizer = MagicMock()
+        recognizer.transcribe_file.return_value = ("hello world", [1, 2])
+        asr_class = MagicMock()
+        asr_class.from_hparams.return_value = recognizer
+
+        env = {
+            "SPEECHBRAIN_SAVEDIR": str(tmp_path / "models"),
+            "SPEECHBRAIN_DEVICE": "cuda:0",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            with patch.object(
+                SpeechBrainProvider, "_get_asr_class", return_value=asr_class
+            ):
+                result = SpeechBrainProvider().transcribe(
+                    str(audio), model="speechbrain/test-model"
+                )
+
+        asr_class.from_hparams.assert_called_once_with(
+            source="speechbrain/test-model",
+            savedir=str(tmp_path / "models"),
+            run_opts={"device": "cuda:0"},
+        )
+        recognizer.transcribe_file.assert_called_once_with(str(audio))
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "hello world"
+        assert result.raw_response == ("hello world", [1, 2])
+
+    def test_from_hparams_omits_unset_savedir_and_defaults_to_cpu(self, tmp_path):
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"wav")
+        recognizer = MagicMock()
+        recognizer.transcribe_file.return_value = "hello"
+        asr_class = MagicMock()
+        asr_class.from_hparams.return_value = recognizer
+
+        with patch.dict("os.environ", {}, clear=True):
+            with patch.object(
+                SpeechBrainProvider, "_get_asr_class", return_value=asr_class
+            ):
+                SpeechBrainProvider().transcribe(str(audio), model="speechbrain/model")
+
+        asr_class.from_hparams.assert_called_once_with(
+            source="speechbrain/model", run_opts={"device": "cpu"}
+        )
+
+    @pytest.mark.parametrize(
+        ("output", "expected"),
+        [
+            ("  direct text  ", "direct text"),
+            (("tuple text", [1, 2, 3]), "tuple text"),
+            (["first", "second"], "first second"),
+            ([("first", [1]), ("second", [2])], "first second"),
+            ([], ""),
+            (None, ""),
+        ],
+    )
+    def test_extracts_common_outputs(self, output, expected):
+        assert SpeechBrainProvider._extract_text(output) == expected
+
+    def test_rejects_unsupported_output(self):
+        with pytest.raises(ValueError, match="Unsupported SpeechBrain"):
+            SpeechBrainProvider._extract_text({"text": "unexpected"})
+
+    def test_missing_audio_fails_before_loading_dependency(self, tmp_path):
+        with patch.object(SpeechBrainProvider, "_get_asr_class") as get_asr_class:
+            with pytest.raises(ValueError, match="does not exist"):
+                SpeechBrainProvider().transcribe(
+                    str(tmp_path / "missing.wav"), model="speechbrain/model"
+                )
+
+        get_asr_class.assert_not_called()
+
+    def test_transcription_failure_is_contextualized(self, tmp_path):
+        audio = tmp_path / "audio.wav"
+        audio.write_bytes(b"wav")
+        recognizer = MagicMock()
+        recognizer.transcribe_file.side_effect = OSError("decoder failed")
+        asr_class = MagicMock()
+        asr_class.from_hparams.return_value = recognizer
+
+        with patch.object(
+            SpeechBrainProvider, "_get_asr_class", return_value=asr_class
+        ):
+            with pytest.raises(
+                RuntimeError, match="SpeechBrain transcription failed: decoder failed"
+            ):
+                SpeechBrainProvider().transcribe(str(audio), model="speechbrain/model")
+
+    def test_lazy_import_uses_maintained_inference_api(self):
+        asr_class = object()
+        asr_module = types.ModuleType("speechbrain.inference.ASR")
+        asr_module.EncoderDecoderASR = asr_class
+        inference_module = types.ModuleType("speechbrain.inference")
+        inference_module.__path__ = []
+        speechbrain_module = types.ModuleType("speechbrain")
+        speechbrain_module.__path__ = []
+
+        fake_modules = {
+            "speechbrain": speechbrain_module,
+            "speechbrain.inference": inference_module,
+            "speechbrain.inference.ASR": asr_module,
+        }
+        with patch.dict(sys.modules, fake_modules):
+            assert SpeechBrainProvider._get_asr_class() is asr_class
+
+    def test_missing_dependency_has_install_hint(self):
+        with patch.dict(sys.modules, {"speechbrain.inference.ASR": None}):
+            with pytest.raises(ImportError, match=r"sapat\[speechbrain\]"):
+                SpeechBrainProvider._get_asr_class()


### PR DESCRIPTION
## Summary

Adds a local SpeechBrain ASR provider to Sapat's current provider registry.

- Uses `speechbrain.inference.ASR.EncoderDecoderASR` lazily, so the base package does not require SpeechBrain.
- Defaults to `speechbrain/asr-crdnn-rnnlm-librispeech` and supports `SPEECHBRAIN_MODEL`, `SPEECHBRAIN_SAVEDIR`, and `SPEECHBRAIN_DEVICE`.
- Adds the optional `sapat[speechbrain]` extra and keeps credentials unnecessary for local inference.
- Returns normalized `TranscriptionResult` text for common SpeechBrain output shapes.
- Adds mocked tests; CI does not download model weights.

## Validation

- `pytest tests/providers/test_speechbrain.py -q` — **18 passed**
- `python -m compileall -q sapat tests` — **PASS**
- `black --check sapat/providers/speechbrain.py tests/providers/test_speechbrain.py` — **PASS**
- `git diff --check` — **PASS**
- Full suite — **193 passed, 1 unrelated pre-existing Windows failure** in `TestWhisperXProvider::test_transcribe_builds_command_and_reads_output` caused by existing `WHISPERX_BINARY` Windows path parsing.

No API keys, private audio, model files, or generated transcripts are committed.

Companion work for daytonaio/content#13 ($150 Algora bounty).