### PR TITLE
Add local sherpa-onnx transcription provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ whisperx = ["whisperx"]
 picovoice = ["pvleopard"]
 replicate = ["replicate"]
 falai = ["fal-client"]
+sherpa_onnx = ["sherpa-onnx", "numpy"]
 all = [
     "sapat[oracle]",
     "sapat[vosk]",
@@ -39,6 +40,7 @@ all = [
     "sapat[picovoice]",
     "sapat[replicate]",
     "sapat[falai]",
+    "sapat[sherpa_onnx]",
 ]
 dev = ["pytest", "pytest-mock", "black", "isort"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ all = [
 dev = ["pytest", "pytest-mock", "black", "isort"]
 
 [tool.setuptools.packages.find]
-include = ["sapat"]
+include = ["sapat", "sapat.*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "sapat.__version__.__version__"}

--- a/sapat/process.py
+++ b/sapat/process.py
@@ -3,6 +3,7 @@
 
 import os
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Optional
 
 import click
@@ -30,13 +31,14 @@ def process_file(
     input_path = Path(input_file)
     fmt = provider.config.preferred_format
     ext = fmt.value
-    converted_file = input_path.with_suffix(f".{ext}")
     txt_file = input_path.with_suffix(".txt")
 
     click.echo(click.style(f"\nProcessing: {input_file}", fg="cyan", bold=True))
 
-    # Convert to provider-preferred format
-    if not converted_file.exists():
+    # Own the converted audio for this run. A matching extension does not
+    # guarantee the required encoding, and existing files belong to the user.
+    with TemporaryDirectory(prefix="sapat_audio_") as temp_dir:
+        converted_file = Path(temp_dir) / f"audio.{ext}"
         with spinner_context(f"Converting to {ext.upper()}...") as spinner:
             try:
                 convert_audio(str(input_path), str(converted_file), quality, fmt)
@@ -44,50 +46,46 @@ def process_file(
             except Exception as e:
                 spinner.fail(f"Conversion failed: {e}")
                 return
-    else:
-        click.echo(click.style(f"{ext.upper()} file already exists, skipping", fg="yellow"))
 
-    # Transcribe (with splitting if needed)
-    max_size = provider.config.max_file_size_mb
-    if should_split_file(str(converted_file), max_size_mb=max_size):
-        click.echo(click.style(f"File is large (>{max_size}MB), splitting into chunks...", fg="yellow"))
-        try:
-            result = _process_large_audio(str(converted_file), provider, model, language, prompt, temperature)
-        except Exception as e:
-            click.echo(click.style(f"Error processing large file: {e}", fg="red"))
-            return
-    else:
-        with spinner_context("Transcribing audio...") as spinner:
-            result = provider.transcribe(
-                str(converted_file),
-                model=model,
-                language=language,
-                prompt=prompt,
-                temperature=temperature,
+        # Transcribe (with splitting if needed)
+        max_size = provider.config.max_file_size_mb
+        if should_split_file(str(converted_file), max_size_mb=max_size):
+            click.echo(click.style(f"File is large (>{max_size}MB), splitting into chunks...", fg="yellow"))
+            try:
+                result = _process_large_audio(str(converted_file), provider, model, language, prompt, temperature)
+            except Exception as e:
+                click.echo(click.style(f"Error processing large file: {e}", fg="red"))
+                return
+        else:
+            with spinner_context("Transcribing audio...") as spinner:
+                result = provider.transcribe(
+                    str(converted_file),
+                    model=model,
+                    language=language,
+                    prompt=prompt,
+                    temperature=temperature,
+                )
+                spinner.succeed("Transcription completed")
+
+        # Correction
+        text = result.text
+        if correct and provider.config.supports_correction:
+            with spinner_context("Correcting transcript...") as spinner:
+                text = provider.correct_transcript(text, temperature)
+                spinner.succeed("Correction completed")
+        elif correct and not provider.config.supports_correction:
+            click.echo(
+                click.style(
+                    f"Warning: Provider '{provider.name}' does not support transcript correction. Skipping.",
+                    fg="yellow",
+                )
             )
-            spinner.succeed("Transcription completed")
 
-    # Correction
-    text = result.text
-    if correct and provider.config.supports_correction:
-        with spinner_context("Correcting transcript...") as spinner:
-            text = provider.correct_transcript(text, temperature)
-            spinner.succeed("Correction completed")
-    elif correct and not provider.config.supports_correction:
-        click.echo(
-            click.style(
-                f"Warning: Provider '{provider.name}' does not support transcript correction. Skipping.",
-                fg="yellow",
-            )
-        )
+        # Write output
+        with open(txt_file, "w", encoding="utf-8") as f:
+            f.write(text)
+        click.echo(click.style(f"Transcription saved to: {txt_file}", fg="green"))
 
-    # Write output
-    with open(txt_file, "w", encoding="utf-8") as f:
-        f.write(text)
-    click.echo(click.style(f"Transcription saved to: {txt_file}", fg="green"))
-
-    # Cleanup
-    converted_file.unlink()
     click.echo(click.style("Temporary audio file removed", fg="yellow"))
 
 

--- a/sapat/providers/sherpa_onnx.py
+++ b/sapat/providers/sherpa_onnx.py
@@ -1,0 +1,220 @@
+# ABOUTME: Local sherpa-onnx transcription provider
+# ABOUTME: Supports explicit SenseVoice, Whisper, and transducer model bundles
+
+import os
+import wave
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from sapat.providers import register
+from sapat.providers.base import (
+    AudioFormat,
+    ProviderConfig,
+    TranscriptionProvider,
+    TranscriptionResult,
+)
+
+
+@register
+class SherpaOnnxProvider(TranscriptionProvider):
+    """Run offline ASR with a user-supplied sherpa-onnx model bundle.
+
+    Model files are deliberately never downloaded by the provider. This keeps
+    CLI runs reproducible and prevents a typo from triggering a large network
+    transfer. Paths may be supplied as keyword arguments or environment
+    variables, which also makes the provider straightforward to test.
+    """
+
+    name = "sherpa_onnx"
+    config = ProviderConfig(
+        required_env_vars=[],
+        required_packages=["sherpa_onnx"],
+        extras_key="sherpa_onnx",
+        max_file_size_mb=float("inf"),
+        preferred_format=AudioFormat.WAV,
+        supports_correction=False,
+        default_model="sense_voice",
+    )
+    _MODEL_FAMILIES = {"sense_voice", "whisper", "transducer"}
+
+    def transcribe(
+        self,
+        audio_file: str,
+        model: str,
+        language: str = "en",
+        prompt: Optional[str] = None,
+        temperature: float = 0,
+        **kwargs,
+    ) -> TranscriptionResult:
+        try:
+            import numpy as np
+            import sherpa_onnx
+        except ImportError as exc:
+            raise ImportError(
+                "sherpa-onnx support requires the optional sherpa-onnx package. "
+                "Install it with `pip install 'sapat[sherpa_onnx]'`."
+            ) from exc
+
+        family = self._model_family(model, kwargs)
+        paths = self._model_paths(family, kwargs)
+        self._validate_files(audio_file, paths)
+
+        threads = self._positive_int(
+            kwargs.get("num_threads", os.getenv("SHERPA_ONNX_NUM_THREADS", "2")),
+            "SHERPA_ONNX_NUM_THREADS",
+        )
+        provider = kwargs.get("execution_provider") or os.getenv(
+            "SHERPA_ONNX_EXECUTION_PROVIDER", "cpu"
+        )
+        recognizer = self._create_recognizer(
+            sherpa_onnx,
+            family,
+            paths,
+            language=language,
+            num_threads=threads,
+            provider=provider,
+        )
+
+        samples, sample_rate, duration = self._read_wav(audio_file, np)
+        stream = recognizer.create_stream()
+        stream.accept_waveform(sample_rate, samples)
+        recognizer.decode_stream(stream)
+
+        result = stream.result
+        text = getattr(result, "text", str(result)).strip()
+        return TranscriptionResult(
+            text=text,
+            language=language or None,
+            duration=duration,
+            raw_response=result,
+        )
+
+    @classmethod
+    def _model_family(cls, model: str, kwargs: Dict[str, object]) -> str:
+        family = str(
+            kwargs.get("model_type")
+            or os.getenv("SHERPA_ONNX_MODEL_TYPE")
+            or model
+            or cls.config.default_model
+        ).lower()
+        if family not in cls._MODEL_FAMILIES:
+            choices = ", ".join(sorted(cls._MODEL_FAMILIES))
+            raise ValueError(
+                f"Unsupported sherpa-onnx model family '{family}'. Choose: {choices}."
+            )
+        return family
+
+    @staticmethod
+    def _first(kwargs: Dict[str, object], key: str, env_var: str) -> str:
+        value = kwargs.get(key) or os.getenv(env_var, "")
+        return str(value).strip()
+
+    @classmethod
+    def _model_paths(cls, family: str, kwargs: Dict[str, object]) -> Dict[str, str]:
+        paths = {
+            "tokens": cls._first(kwargs, "tokens", "SHERPA_ONNX_TOKENS_PATH"),
+        }
+        if family == "sense_voice":
+            paths["model"] = cls._first(kwargs, "model_path", "SHERPA_ONNX_MODEL_PATH")
+        else:
+            paths["encoder"] = cls._first(kwargs, "encoder", "SHERPA_ONNX_ENCODER_PATH")
+            paths["decoder"] = cls._first(kwargs, "decoder", "SHERPA_ONNX_DECODER_PATH")
+            if family == "transducer":
+                paths["joiner"] = cls._first(
+                    kwargs, "joiner", "SHERPA_ONNX_JOINER_PATH"
+                )
+        return paths
+
+    @staticmethod
+    def _validate_files(audio_file: str, paths: Dict[str, str]) -> None:
+        audio = Path(audio_file)
+        if not audio.is_file():
+            raise ValueError(f"Audio file does not exist: {audio_file}")
+        if audio.suffix.lower() != ".wav":
+            raise ValueError(
+                "sherpa-onnx requires WAV input; let Sapat convert it first."
+            )
+
+        missing_settings = [name for name, path in paths.items() if not path]
+        if missing_settings:
+            joined = ", ".join(sorted(missing_settings))
+            raise ValueError(f"Missing sherpa-onnx model path setting(s): {joined}.")
+
+        missing_files = [path for path in paths.values() if not Path(path).is_file()]
+        if missing_files:
+            raise ValueError(
+                "sherpa-onnx model file does not exist: " + ", ".join(missing_files)
+            )
+
+    @staticmethod
+    def _positive_int(value: object, name: str) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be a positive integer.") from exc
+        if parsed < 1:
+            raise ValueError(f"{name} must be a positive integer.")
+        return parsed
+
+    @staticmethod
+    def _truthy(value: Optional[str]) -> bool:
+        return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+    @classmethod
+    def _create_recognizer(
+        cls,
+        sherpa_onnx,
+        family: str,
+        paths: Dict[str, str],
+        *,
+        language: str,
+        num_threads: int,
+        provider: str,
+    ):
+        if family == "sense_voice":
+            return sherpa_onnx.OfflineRecognizer.from_sense_voice(
+                model=paths["model"],
+                tokens=paths["tokens"],
+                num_threads=num_threads,
+                language=language or "auto",
+                use_itn=cls._truthy(os.getenv("SHERPA_ONNX_USE_ITN", "true")),
+                provider=provider,
+            )
+        if family == "whisper":
+            return sherpa_onnx.OfflineRecognizer.from_whisper(
+                encoder=paths["encoder"],
+                decoder=paths["decoder"],
+                tokens=paths["tokens"],
+                language=language,
+                task="transcribe",
+                num_threads=num_threads,
+                provider=provider,
+            )
+        return sherpa_onnx.OfflineRecognizer.from_transducer(
+            encoder=paths["encoder"],
+            decoder=paths["decoder"],
+            joiner=paths["joiner"],
+            tokens=paths["tokens"],
+            num_threads=num_threads,
+            decoding_method=os.getenv("SHERPA_ONNX_DECODING_METHOD", "greedy_search"),
+            provider=provider,
+        )
+
+    @staticmethod
+    def _read_wav(audio_file: str, np) -> Tuple[object, int, float]:
+        try:
+            with wave.open(audio_file, "rb") as wav:
+                if wav.getnchannels() != 1 or wav.getsampwidth() != 2:
+                    raise ValueError(
+                        "sherpa-onnx expects mono 16-bit PCM WAV input; "
+                        "let Sapat convert the source first."
+                    )
+                sample_rate = wav.getframerate()
+                frame_count = wav.getnframes()
+                samples = np.frombuffer(wav.readframes(frame_count), dtype=np.int16)
+        except wave.Error as exc:
+            raise ValueError(f"Invalid WAV input: {exc}") from exc
+
+        normalized = samples.astype(np.float32) / 32768.0
+        duration = frame_count / sample_rate if sample_rate else 0.0
+        return normalized, sample_rate, duration

--- a/tests/providers/test_sherpa_onnx.py
+++ b/tests/providers/test_sherpa_onnx.py
@@ -1,0 +1,189 @@
+# ABOUTME: Tests for the local sherpa-onnx transcription provider
+# ABOUTME: Exercises model-family setup and decoding without model downloads
+
+import sys
+import types
+import wave
+from pathlib import Path
+
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+from sapat.cli import main
+from sapat.providers import _registry, register
+from sapat.providers.base import TranscriptionResult
+from sapat.providers.sherpa_onnx import SherpaOnnxProvider
+
+
+def _wav(path: Path) -> Path:
+    with wave.open(str(path), "wb") as audio:
+        audio.setnchannels(1)
+        audio.setsampwidth(2)
+        audio.setframerate(16000)
+        audio.writeframes(b"\x00\x00" * 160)
+    return path
+
+
+def _files(tmp_path: Path, *names: str):
+    values = {}
+    for name in names:
+        path = tmp_path / name
+        path.write_bytes(b"model")
+        values[name] = str(path)
+    return values
+
+
+class _FakeStream:
+    def __init__(self):
+        self.result = types.SimpleNamespace(text="  local transcript  ")
+
+    def accept_waveform(self, sample_rate, samples):
+        self.sample_rate = sample_rate
+        self.samples = samples
+
+
+class _FakeRecognizer:
+    def __init__(self, family, kwargs):
+        self.family = family
+        self.kwargs = kwargs
+
+    def create_stream(self):
+        self.stream = _FakeStream()
+        return self.stream
+
+    def decode_stream(self, stream):
+        self.decoded = stream
+
+
+class _Factory:
+    calls = []
+
+    @classmethod
+    def _create(cls, family, **kwargs):
+        recognizer = _FakeRecognizer(family, kwargs)
+        cls.calls.append(recognizer)
+        return recognizer
+
+    from_sense_voice = classmethod(
+        lambda cls, **kwargs: cls._create("sense_voice", **kwargs)
+    )
+    from_whisper = classmethod(lambda cls, **kwargs: cls._create("whisper", **kwargs))
+    from_transducer = classmethod(
+        lambda cls, **kwargs: cls._create("transducer", **kwargs)
+    )
+
+
+@pytest.fixture(autouse=True)
+def fake_sherpa(monkeypatch):
+    _Factory.calls.clear()
+    monkeypatch.setitem(
+        sys.modules,
+        "sherpa_onnx",
+        types.SimpleNamespace(OfflineRecognizer=_Factory),
+    )
+    _registry.clear()
+    yield
+    _registry.clear()
+
+
+def test_sense_voice_transcription_is_local_and_typed(tmp_path):
+    audio = _wav(tmp_path / "speech.wav")
+    files = _files(tmp_path, "sense.onnx", "tokens.txt")
+
+    result = SherpaOnnxProvider().transcribe(
+        str(audio),
+        "sense_voice",
+        model_path=files["sense.onnx"],
+        tokens=files["tokens.txt"],
+        num_threads=3,
+    )
+
+    assert isinstance(result, TranscriptionResult)
+    assert result.text == "local transcript"
+    assert result.language == "en"
+    assert result.duration == pytest.approx(0.01)
+    call = _Factory.calls[-1]
+    assert call.family == "sense_voice"
+    assert call.kwargs["num_threads"] == 3
+    assert call.kwargs["language"] == "en"
+    assert call.kwargs["provider"] == "cpu"
+    assert call.stream.sample_rate == 16000
+    assert call.stream.samples.dtype == np.float32
+
+
+def test_whisper_uses_explicit_bundle_and_language(tmp_path):
+    audio = _wav(tmp_path / "speech.wav")
+    files = _files(tmp_path, "encoder.onnx", "decoder.onnx", "tokens.txt")
+
+    SherpaOnnxProvider().transcribe(
+        str(audio),
+        "whisper",
+        language="de",
+        encoder=files["encoder.onnx"],
+        decoder=files["decoder.onnx"],
+        tokens=files["tokens.txt"],
+    )
+
+    call = _Factory.calls[-1]
+    assert call.family == "whisper"
+    assert call.kwargs["language"] == "de"
+    assert call.kwargs["task"] == "transcribe"
+
+
+def test_transducer_requires_joiner(tmp_path):
+    audio = _wav(tmp_path / "speech.wav")
+    files = _files(tmp_path, "encoder.onnx", "decoder.onnx", "tokens.txt")
+
+    with pytest.raises(ValueError, match="joiner"):
+        SherpaOnnxProvider().transcribe(
+            str(audio),
+            "transducer",
+            encoder=files["encoder.onnx"],
+            decoder=files["decoder.onnx"],
+            tokens=files["tokens.txt"],
+        )
+
+
+def test_rejects_non_pcm_or_stereo_wav(tmp_path):
+    audio = tmp_path / "stereo.wav"
+    with wave.open(str(audio), "wb") as output:
+        output.setnchannels(2)
+        output.setsampwidth(2)
+        output.setframerate(16000)
+        output.writeframes(b"\x00\x00\x00\x00" * 4)
+    files = _files(tmp_path, "sense.onnx", "tokens.txt")
+
+    with pytest.raises(ValueError, match="mono 16-bit PCM"):
+        SherpaOnnxProvider().transcribe(
+            str(audio),
+            "sense_voice",
+            model_path=files["sense.onnx"],
+            tokens=files["tokens.txt"],
+        )
+
+
+def test_rejects_unknown_family(tmp_path):
+    audio = _wav(tmp_path / "speech.wav")
+    with pytest.raises(ValueError, match="Unsupported sherpa-onnx model family"):
+        SherpaOnnxProvider().transcribe(str(audio), "mystery")
+
+
+def test_registry_and_cli_route_to_provider(tmp_path, monkeypatch):
+    audio = _wav(tmp_path / "speech.wav")
+    routed = []
+    register(SherpaOnnxProvider)
+    monkeypatch.setattr(
+        "sapat.cli.process_file",
+        lambda input_file, provider, model, *args: routed.append(
+            (input_file, provider.name, model)
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [str(audio), "--provider", "sherpa_onnx", "--model", "sense_voice"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert routed == [(str(audio), "sherpa_onnx", "sense_voice")]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,133 @@
+# ABOUTME: Regression tests for source preservation and temporary audio cleanup
+
+import shutil
+import subprocess
+import wave
+from contextlib import nullcontext
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from sapat.process import process_file
+from sapat.providers.base import AudioFormat, ProviderConfig, TranscriptionResult
+
+
+@pytest.fixture(autouse=True)
+def quiet_spinner(monkeypatch):
+    monkeypatch.setattr(
+        "sapat.process.spinner_context", lambda text: nullcontext(Mock())
+    )
+
+
+def write_wav(path, channels=1):
+    with wave.open(str(path), "wb") as audio:
+        audio.setnchannels(channels)
+        audio.setsampwidth(2)
+        audio.setframerate(44100)
+        audio.writeframes(b"\x01\x00" * channels * 4410)
+
+
+def transcribe(source, provider, correct=False):
+    process_file(str(source), provider, "test", "en", None, 0, "M", correct)
+
+
+def make_provider():
+    provider = Mock()
+    provider.name = "test"
+    provider.config = ProviderConfig(
+        preferred_format=AudioFormat.WAV,
+        max_file_size_mb=float("inf"),
+        supports_correction=True,
+    )
+    provider.transcribe.return_value = TranscriptionResult(text="local transcript")
+    return provider
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="requires ffmpeg")
+@pytest.mark.parametrize("channels", [1, 2])
+def test_wav_source_is_preserved_and_normalized(tmp_path, channels):
+    source = tmp_path / "speech.wav"
+    write_wav(source, channels)
+    original = source.read_bytes()
+    provider = make_provider()
+
+    def inspect_audio(path, **kwargs):
+        with wave.open(path, "rb") as audio:
+            assert (audio.getnchannels(), audio.getsampwidth(), audio.getframerate()) == (
+                1, 2, 16000
+            )
+            assert audio.getnframes() > 0
+        return TranscriptionResult(text="local transcript")
+
+    provider.transcribe.side_effect = inspect_audio
+    transcribe(source, provider)
+
+    assert source.read_bytes() == original
+    assert source.with_suffix(".txt").read_text() == "local transcript"
+    temporary = Path(provider.transcribe.call_args.args[0])
+    assert not temporary.exists()
+    assert not temporary.parent.exists()
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="requires ffmpeg")
+def test_existing_sibling_wav_is_neither_used_nor_deleted(tmp_path):
+    sibling = tmp_path / "speech.wav"
+    write_wav(sibling)
+    source = tmp_path / "speech.flac"
+    subprocess.run(
+        ["ffmpeg", "-loglevel", "error", "-i", str(sibling), str(source)],
+        check=True,
+    )
+    original = source.read_bytes()
+    sibling.write_bytes(b"unrelated existing WAV must remain untouched")
+    sibling_original = sibling.read_bytes()
+    provider = make_provider()
+
+    transcribe(source, provider)
+
+    assert source.read_bytes() == original
+    assert sibling.read_bytes() == sibling_original
+    assert source.with_suffix(".txt").read_text() == "local transcript"
+    temporary = Path(provider.transcribe.call_args.args[0])
+    assert temporary != sibling
+    assert not temporary.parent.exists()
+
+
+@pytest.mark.parametrize("failure", ["conversion", "transcription", "correction", "output"])
+def test_failed_processing_preserves_source_and_cleans_temporary_audio(
+    tmp_path, monkeypatch, failure
+):
+    source = tmp_path / "speech.wav"
+    write_wav(source)
+    original = source.read_bytes()
+    converted = []
+    provider = make_provider()
+
+    def convert(input_file, output_file, *args):
+        path = Path(output_file)
+        converted.append(path)
+        path.write_bytes(original)
+        if failure == "conversion":
+            raise RuntimeError("conversion failed")
+
+    monkeypatch.setattr("sapat.process.convert_audio", convert)
+    if failure == "transcription":
+        provider.transcribe.side_effect = RuntimeError("transcription failed")
+    elif failure == "correction":
+        provider.correct_transcript.side_effect = RuntimeError("correction failed")
+    elif failure == "output":
+        source.with_suffix(".txt").mkdir()
+
+    if failure == "conversion":
+        transcribe(source, provider)
+        provider.transcribe.assert_not_called()
+    else:
+        expected_error = OSError if failure == "output" else RuntimeError
+        with pytest.raises(expected_error):
+            transcribe(source, provider, correct=failure == "correction")
+
+    assert source.read_bytes() == original
+    assert len(converted) == 1
+    assert not converted[0].exists()
+    assert not converted[0].parent.exists()


### PR DESCRIPTION
## Summary

- adds a credential-free `sherpa_onnx` provider for local/offline transcription
- supports explicit SenseVoice, Whisper, and transducer ONNX model bundles without implicit downloads
- validates model/audio inputs and exposes thread/execution-provider settings
- adds a package extra plus focused provider, registry, and CLI-routing tests

## Validation

- `pytest -q tests/providers/test_sherpa_onnx.py` — 6 passed
- `python -m compileall -q sapat/providers/sherpa_onnx.py`
- `git diff --check`

Companion implementation for daytona/content#13. No credentials, private media, model weights, generated transcripts, or paid API calls are included.