### PR TITLE
Add Deepgram prerecorded transcription with HTTP contract tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ AZURE_OPENAI_API_VERSION_CHAT=2023-03-15-preview
 # --- Groq ---
 GROQ_API_KEY=
 
+# --- Deepgram prerecorded audio ---
+DEEPGRAM_API_KEY=
+
 # --- DeepInfra ---
 DEEPINFRA_API_KEY=
 

--- a/.github/workflows/deepgram.yml
+++ b/.github/workflows/deepgram.yml
@@ -1,0 +1,48 @@
+name: Deepgram provider
+
+on:
+  push:
+    paths:
+      - 'sapat/**'
+      - 'tests/test_deepgram.py'
+      - 'pyproject.toml'
+      - '.github/workflows/deepgram.yml'
+  pull_request:
+    paths:
+      - 'sapat/**'
+      - 'tests/test_deepgram.py'
+      - 'pyproject.toml'
+      - '.github/workflows/deepgram.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-and-wheel:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.12']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install test and build dependencies
+        run: python -m pip install '.[dev]' build
+      - name: Run offline provider contracts
+        run: python -m pytest tests/test_deepgram.py -v
+      - name: Build and install the distribution
+        run: |
+          python -m build --wheel
+          python -m pip install --force-reinstall --no-deps dist/*.whl
+      - name: Discover the provider outside the checkout
+        working-directory: ${{ runner.temp }}
+        run: |
+          python -c "from sapat.providers import get_provider; p = get_provider('deepgram'); assert p is not None; assert p.config.default_model == 'nova-3'; print('Installed wheel discovers Deepgram')"
+          sapat --help

--- a/.github/workflows/deepgram.yml
+++ b/.github/workflows/deepgram.yml
@@ -43,6 +43,8 @@ jobs:
           python -m pip install --force-reinstall --no-deps "$RUNNER_TEMP"/sapat-wheel/*.whl
       - name: Discover the provider outside the checkout
         working-directory: ${{ runner.temp }}
+        env:
+          DEEPGRAM_API_KEY: test-only-key
         run: |
           python -c "from sapat.providers import get_provider; p = get_provider('deepgram'); assert p is not None; assert p.config.default_model == 'nova-3'; print('Installed wheel discovers Deepgram')"
           sapat --help

--- a/.github/workflows/deepgram.yml
+++ b/.github/workflows/deepgram.yml
@@ -39,8 +39,8 @@ jobs:
         run: python -m pytest tests/test_deepgram.py -v
       - name: Build and install the distribution
         run: |
-          python -m build --wheel
-          python -m pip install --force-reinstall --no-deps dist/*.whl
+          python -m build --wheel --outdir "$RUNNER_TEMP/sapat-wheel"
+          python -m pip install --force-reinstall --no-deps "$RUNNER_TEMP"/sapat-wheel/*.whl
       - name: Discover the provider outside the checkout
         working-directory: ${{ runner.temp }}
         run: |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@ This tool automates the process of transcribing video files using multiple trans
 
 ## Features
 
+### Deepgram (current provider CLI)
+
+Set `DEEPGRAM_API_KEY` in your environment or `.env`, install the project with
+`python -m pip install .`, then run:
+
+```bash
+sapat recording.mp4 --provider deepgram --model nova-3 --language en
+```
+
+The provider uses Deepgram's [prerecorded audio REST API](https://developers.deepgram.com/docs/pre-recorded-audio)
+with binary audio upload and smart formatting. No additional SDK is required.
+An empty language (`--language ''`) requests automatic language detection.
+The shared transcription prompt and temperature options are ignored with a
+warning because they do not map to this endpoint. LLM correction is unsupported.
+Deepgram is a hosted service: API requests require an account and may incur charges.
+
+Offline contract tests (no API key or paid requests required):
+
+```bash
+python -m pip install '.[dev]'
+python -m pytest tests/test_deepgram.py
+```
+
+The tests check HTTP request/response handling, not recognition accuracy or live
+service availability. The older `--api` examples below describe the legacy CLI;
+use `--provider` with the current package.
+
 - Converts video files to MP3 format using ffmpeg
 - Supports transcription using Azure OpenAI, Groq, and OpenAI APIs
 - Supports processing of individual video files or entire directories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ all = [
 dev = ["pytest", "pytest-mock", "black", "isort"]
 
 [tool.setuptools.packages.find]
-include = ["sapat"]
+include = ["sapat", "sapat.*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "sapat.__version__.__version__"}

--- a/sapat/providers/deepgram.py
+++ b/sapat/providers/deepgram.py
@@ -1,0 +1,85 @@
+"""Deepgram prerecorded transcription using its binary-upload REST endpoint."""
+
+import logging
+import mimetypes
+import os
+from typing import Optional
+
+import requests
+
+from sapat.providers import register
+from sapat.providers.base import (
+    ProviderConfig,
+    TranscriptionProvider,
+    TranscriptionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@register
+class DeepgramProvider(TranscriptionProvider):
+    name = "deepgram"
+    config = ProviderConfig(
+        required_env_vars=["DEEPGRAM_API_KEY"],
+        default_model="nova-3",
+    )
+
+    def transcribe(
+        self,
+        audio_file: str,
+        model: str,
+        language: str = "en",
+        prompt: Optional[str] = None,
+        temperature: float = 0,
+        **kwargs,
+    ) -> TranscriptionResult:
+        api_key = os.getenv("DEEPGRAM_API_KEY")
+        if not api_key:
+            raise ValueError("Set DEEPGRAM_API_KEY to use Deepgram")
+        if prompt or temperature:
+            logger.warning(
+                "Deepgram does not use Sapat's transcription prompt or temperature; "
+                "these options are ignored"
+            )
+        params = {"model": model, "smart_format": "true"}
+        if language:
+            params["language"] = language
+        else:
+            params["detect_language"] = "true"
+        content_type = (
+            mimetypes.guess_type(str(audio_file))[0] or "application/octet-stream"
+        )
+        with open(audio_file, "rb") as audio:
+            response = requests.post(
+                "https://api.deepgram.com/v1/listen",
+                headers={
+                    "Authorization": f"Token {api_key}",
+                    "Content-Type": content_type,
+                },
+                params=params,
+                data=audio,
+                timeout=(10, 300),
+            )
+        if response.status_code != 200:
+            # Do not echo response bodies, which may include submitted content.
+            raise RuntimeError(
+                f"Deepgram transcription failed (HTTP {response.status_code})"
+            )
+        try:
+            result = response.json()
+            channel = result["results"]["channels"][0]
+            alternative = channel["alternatives"][0]
+            text = alternative["transcript"]
+            if not isinstance(text, str):
+                raise TypeError("transcript must be a string")
+        except (ValueError, KeyError, IndexError, TypeError) as exc:
+            raise RuntimeError(
+                "Deepgram returned an invalid transcription response"
+            ) from exc
+        return TranscriptionResult(
+            text=text,
+            language=channel.get("detected_language") or language or None,
+            duration=result.get("metadata", {}).get("duration"),
+            raw_response=result,
+        )

--- a/tests/test_deepgram.py
+++ b/tests/test_deepgram.py
@@ -1,0 +1,147 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from sapat.providers.deepgram import DeepgramProvider
+
+
+@pytest.fixture
+def audio(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "test-only-key")
+    path = tmp_path / "speech.mp3"
+    path.write_bytes(b"test audio bytes")
+    return path
+
+
+def payload(text="Hello, world."):
+    return {
+        "metadata": {"duration": 1.25},
+        "results": {
+            "channels": [
+                {
+                    "detected_language": "en",
+                    "alternatives": [{"transcript": text}],
+                }
+            ]
+        },
+    }
+
+
+def test_binary_upload_and_response(audio, monkeypatch):
+    captured = {}
+
+    def post(url, **kwargs):
+        captured.update(url=url, **kwargs)
+        assert kwargs["data"].read() == audio.read_bytes()
+        return Mock(status_code=200, json=lambda: payload())
+
+    monkeypatch.setattr(requests, "post", post)
+    result = DeepgramProvider().transcribe(str(audio), "nova-3", language="en-GB")
+    assert captured["url"] == "https://api.deepgram.com/v1/listen"
+    assert captured["headers"] == {
+        "Authorization": "Token test-only-key",
+        "Content-Type": "audio/mpeg",
+    }
+    assert captured["params"] == {
+        "model": "nova-3",
+        "language": "en-GB",
+        "smart_format": "true",
+    }
+    assert captured["timeout"] == (10, 300)
+    assert captured["data"].closed
+    assert result.text == "Hello, world."
+    assert result.language == "en"
+    assert result.duration == 1.25
+
+
+def test_auto_language_and_empty_speech(audio, monkeypatch, caplog):
+    post = Mock(return_value=Mock(status_code=200, json=lambda: payload("")))
+    monkeypatch.setattr(requests, "post", post)
+    result = DeepgramProvider().transcribe(
+        str(audio), "nova-3", language="", prompt="hint", temperature=0.5
+    )
+    assert result.text == ""
+    assert post.call_args.kwargs["params"] == {
+        "model": "nova-3",
+        "smart_format": "true",
+        "detect_language": "true",
+    }
+    assert "ignored" in caplog.text
+
+
+@pytest.mark.parametrize("status", [400, 401, 429, 500])
+def test_http_errors_do_not_echo_body(audio, monkeypatch, status):
+    monkeypatch.setattr(
+        requests,
+        "post",
+        Mock(return_value=Mock(status_code=status, text="private audio content")),
+    )
+    with pytest.raises(RuntimeError, match=f"HTTP {status}") as exc:
+        DeepgramProvider().transcribe(str(audio), "nova-3")
+    assert "private" not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {},
+        {"results": {"channels": []}},
+        {"results": {"channels": [{"alternatives": []}]}},
+        payload(None),
+    ],
+)
+def test_malformed_response_is_not_empty_success(audio, monkeypatch, data):
+    monkeypatch.setattr(
+        requests, "post", Mock(return_value=Mock(status_code=200, json=lambda: data))
+    )
+    with pytest.raises(RuntimeError, match="invalid transcription response"):
+        DeepgramProvider().transcribe(str(audio), "nova-3")
+
+
+def test_missing_key_fails_before_network(audio, monkeypatch):
+    monkeypatch.delenv("DEEPGRAM_API_KEY")
+    post = Mock()
+    monkeypatch.setattr(requests, "post", post)
+    with pytest.raises(ValueError, match="DEEPGRAM_API_KEY"):
+        DeepgramProvider().transcribe(str(audio), "nova-3")
+    post.assert_not_called()
+
+
+def test_timeout_closes_audio(audio, monkeypatch):
+    opened = []
+
+    def post(url, **kwargs):
+        opened.append(kwargs["data"])
+        raise requests.Timeout("timed out")
+
+    monkeypatch.setattr(requests, "post", post)
+    with pytest.raises(requests.Timeout):
+        DeepgramProvider().transcribe(str(audio), "nova-3")
+    assert opened[0].closed
+
+
+def test_invalid_json(audio, monkeypatch):
+    response = Mock(status_code=200)
+    response.json.side_effect = ValueError("not JSON")
+    monkeypatch.setattr(requests, "post", Mock(return_value=response))
+    with pytest.raises(RuntimeError, match="invalid transcription response"):
+        DeepgramProvider().transcribe(str(audio), "nova-3")
+
+
+def test_provider_discovery_in_fresh_process(audio):
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from sapat.providers import get_provider; "
+            "p = get_provider('deepgram'); assert p is not None; "
+            "assert p.config.default_model == 'nova-3'",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Adds `--provider deepgram` using the documented binary-upload `/v1/listen` endpoint, with Nova-3 as the default, explicit/automatic language handling, smart formatting, bounded connect/read timeouts, and validation of the transcript response. HTTP errors report status without echoing potentially sensitive response content. Unsupported shared prompt/temperature settings generate a warning.

Also includes `sapat.*` in package discovery: otherwise built wheels omit the provider subpackage, including this integration. Adds environment and current-CLI documentation.

Validation: 14 new offline tests pass, including binary request content, response parsing, silence, malformed responses, missing credentials, HTTP failures, timeouts/file closure and fresh-process provider discovery. Full suite: 189 passed, one failure in unchanged WhisperX Windows path handling (POSIX shlex removes backslashes); reproduced separately. Wheel build passed. No live Deepgram request or recognition-quality claim is made.

Prepared with AI assistance and tested locally. This is the implementation companion for daytona/content#13.

Linux CI now passes on Python 3.10 and 3.12: all 14 provider contract tests, wheel build/install, and discovery plus CLI help from outside the checkout. Workflow uses a dummy key and makes no live transcription requests. Verified run: https://github.com/honanevan/sapat/actions/runs/34167025609
