### PR TITLE
feat(providers): add Azure AI Speech

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,17 @@ AZURE_OPENAI_STT_API_VERSION=2024-06-01
 AZURE_OPENAI_DEPLOYMENT_NAME_CHAT=gpt-4o
 AZURE_OPENAI_API_VERSION_CHAT=2023-03-15-preview
 
+
+# --- Azure AI Speech ---
+AZURE_SPEECH_KEY=
+AZURE_SPEECH_ENDPOINT=https://your-speech-resource.cognitiveservices.azure.com
+# Optional fallback when a resource endpoint is not configured
+AZURE_SPEECH_REGION=
+# Optional: simple or detailed
+AZURE_SPEECH_RESPONSE_FORMAT=simple
+# Optional: masked, removed, or raw
+AZURE_SPEECH_PROFANITY=masked
+
 # --- Groq ---
 GROQ_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This tool automates the process of transcribing video files using multiple trans
 - ffmpeg installed and available in the system PATH
 - API access for one or more supported services:
   - Azure OpenAI API
+  - Azure AI Speech resource
   - Groq Cloud API
   - OpenAI API
 
@@ -54,6 +55,36 @@ This tool automates the process of transcribing video files using multiple trans
    OPENAI_API_ENDPOINT=https://api.openai.com/v1/audio/transcriptions
    OPENAI_MODEL_NAME_CHAT=gpt-4o
    ```
+
+### Azure AI Speech provider
+
+Sapat can also use Azure AI Speech directly through the short-audio Speech to
+text REST API. This is separate from the Azure OpenAI provider: Azure OpenAI
+uses a Whisper deployment, while `azure_speech` uses a Speech resource key and
+endpoint.
+
+Add these variables to `.env`:
+
+```bash
+AZURE_SPEECH_KEY=your_speech_resource_key
+AZURE_SPEECH_ENDPOINT=https://your-speech-resource.cognitiveservices.azure.com
+# Optional fallback when a resource endpoint is not configured
+AZURE_SPEECH_REGION=
+# Optional: simple or detailed
+AZURE_SPEECH_RESPONSE_FORMAT=simple
+# Optional: masked, removed, or raw
+AZURE_SPEECH_PROFANITY=masked
+```
+
+Run it with:
+
+```bash
+sapat demo.mp4 --provider azure_speech --language en-US
+```
+
+The provider converts input audio to 16 kHz mono WAV before sending it to Azure
+AI Speech. The short-audio REST API is designed for direct requests up to about
+60 seconds, so Sapat keeps chunk size conservative for this provider.
 
 ## Building and Installing the Package
 

--- a/sapat/providers/azure_speech.py
+++ b/sapat/providers/azure_speech.py
@@ -1,0 +1,223 @@
+# ABOUTME: Azure AI Speech REST transcription provider
+# ABOUTME: Sends 16 kHz mono WAV audio to the short-audio speech-to-text API
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from sapat.providers import register
+from sapat.providers.base import (AudioFormat, ProviderConfig,
+                                  TranscriptionProvider, TranscriptionResult)
+
+LANGUAGE_ALIASES = {
+    "bg": "bg-BG",
+    "de": "de-DE",
+    "en": "en-US",
+    "es": "es-ES",
+    "fr": "fr-FR",
+    "it": "it-IT",
+    "ja": "ja-JP",
+    "pt": "pt-BR",
+    "ru": "ru-RU",
+    "zh": "zh-CN",
+}
+
+RECOGNITION_MODES = {
+    "conversation": "conversation",
+    "default": "conversation",
+    "dictation": "dictation",
+    "interactive": "interactive",
+}
+
+RESPONSE_FORMATS = {"simple", "detailed"}
+PROFANITY_MODES = {"masked", "removed", "raw"}
+
+
+@register
+class AzureSpeechProvider(TranscriptionProvider):
+    """Azure AI Speech short-audio REST transcription provider."""
+
+    name = "azure_speech"
+    config = ProviderConfig(
+        required_env_vars=["AZURE_SPEECH_KEY"],
+        max_file_size_mb=1.8,
+        preferred_format=AudioFormat.WAV,
+        supports_correction=False,
+        default_model="conversation",
+    )
+
+    def __init__(self):
+        super().__init__()
+        self.api_key = os.getenv("AZURE_SPEECH_KEY", "")
+        self.region = os.getenv("AZURE_SPEECH_REGION", "")
+        self.endpoint = os.getenv("AZURE_SPEECH_ENDPOINT", "")
+        self.response_format = os.getenv(
+            "AZURE_SPEECH_RESPONSE_FORMAT", "simple"
+        ).lower()
+        self.profanity = os.getenv("AZURE_SPEECH_PROFANITY")
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return bool(
+            os.getenv("AZURE_SPEECH_KEY")
+            and (os.getenv("AZURE_SPEECH_ENDPOINT") or os.getenv("AZURE_SPEECH_REGION"))
+        )
+
+    def resolve_model(self, model_alias: str) -> str:
+        return RECOGNITION_MODES.get(model_alias, model_alias)
+
+    def transcribe(
+        self,
+        audio_file: str,
+        model: str,
+        language: str = "en",
+        prompt: Optional[str] = None,
+        temperature: float = 0,
+        **kwargs,
+    ) -> TranscriptionResult:
+        recognition_mode = self.resolve_model(model or self.config.default_model)
+        url = self._build_endpoint(recognition_mode)
+        params = self._build_params(language)
+        headers = {
+            "Ocp-Apim-Subscription-Key": self.api_key,
+            "Content-Type": self._content_type(audio_file),
+            "Accept": "application/json",
+        }
+
+        with open(audio_file, "rb") as f:
+            response = requests.post(
+                url,
+                headers=headers,
+                params=params,
+                data=f.read(),
+            )
+
+        if response.status_code != 200:
+            raise RuntimeError(
+                "Azure AI Speech transcription failed "
+                f"({response.status_code}): {self._error_text(response)}"
+            )
+
+        payload = response.json()
+        return self._parse_result(payload, params["language"])
+
+    def _build_endpoint(self, recognition_mode: str) -> str:
+        if recognition_mode not in RECOGNITION_MODES.values():
+            raise ValueError(
+                "Azure AI Speech recognition mode must be one of: "
+                "conversation, dictation, interactive."
+            )
+
+        configured = self.endpoint.strip().rstrip("/")
+        if configured:
+            lowered = configured.lower()
+            if lowered.endswith("/cognitiveservices/v1"):
+                return configured
+            if "/speech/recognition/" in lowered:
+                return f"{configured}/cognitiveservices/v1"
+
+            if "cognitiveservices.azure.com" in lowered:
+                path_prefix = "stt/speech/recognition"
+            else:
+                path_prefix = "speech/recognition"
+            return f"{configured}/{path_prefix}/{recognition_mode}/cognitiveservices/v1"
+
+        region = self.region.strip()
+        if not region:
+            raise ValueError(
+                "Set AZURE_SPEECH_ENDPOINT or AZURE_SPEECH_REGION before using "
+                "azure_speech."
+            )
+        return (
+            f"https://{region}.stt.speech.microsoft.com/"
+            f"speech/recognition/{recognition_mode}/cognitiveservices/v1"
+        )
+
+    def _build_params(self, language: str) -> dict:
+        response_format = self.response_format or "simple"
+        if response_format not in RESPONSE_FORMATS:
+            raise ValueError(
+                "AZURE_SPEECH_RESPONSE_FORMAT must be 'simple' or 'detailed'."
+            )
+
+        params = {
+            "language": self._normalize_language(language),
+            "format": response_format,
+        }
+
+        if self.profanity:
+            profanity = self.profanity.lower()
+            if profanity not in PROFANITY_MODES:
+                raise ValueError(
+                    "AZURE_SPEECH_PROFANITY must be 'masked', 'removed', or 'raw'."
+                )
+            params["profanity"] = profanity
+
+        return params
+
+    def _parse_result(self, payload: dict, language: str) -> TranscriptionResult:
+        status = payload.get("RecognitionStatus")
+        if status == "NoMatch":
+            return TranscriptionResult(text="", language=language, raw_response=payload)
+        if status and status != "Success":
+            raise RuntimeError(
+                f"Azure AI Speech recognition failed with status '{status}'."
+            )
+
+        text = self._extract_text(payload)
+        return TranscriptionResult(
+            text=text,
+            language=language,
+            duration=self._duration_seconds(payload),
+            raw_response=payload,
+        )
+
+    @staticmethod
+    def _extract_text(payload: dict) -> str:
+        if payload.get("DisplayText"):
+            return payload["DisplayText"]
+
+        for candidate in payload.get("NBest", []):
+            for key in ("Display", "Lexical", "ITN", "MaskedITN"):
+                value = candidate.get(key)
+                if value:
+                    return value
+        return ""
+
+    @staticmethod
+    def _duration_seconds(payload: dict) -> Optional[float]:
+        duration = payload.get("Duration")
+        try:
+            return int(duration) / 10_000_000 if duration is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _normalize_language(language: str) -> str:
+        if not language:
+            return "en-US"
+        return LANGUAGE_ALIASES.get(language.lower(), language)
+
+    @staticmethod
+    def _content_type(audio_file: str) -> str:
+        extension = Path(audio_file).suffix.lower()
+        if extension == ".ogg":
+            return "audio/ogg; codecs=opus"
+        return "audio/wav; codecs=audio/pcm; samplerate=16000"
+
+    @staticmethod
+    def _error_text(response) -> str:
+        try:
+            payload = response.json()
+        except ValueError:
+            return response.text
+
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict) and error.get("message"):
+                return error["message"]
+            if payload.get("message"):
+                return payload["message"]
+        return response.text

--- a/sapat/providers/azure_speech.py
+++ b/sapat/providers/azure_speech.py
@@ -2,7 +2,6 @@
 # ABOUTME: Sends 16 kHz mono WAV audio to the short-audio speech-to-text API
 
 import os
-from pathlib import Path
 from typing import Optional
 
 import requests
@@ -82,7 +81,7 @@ class AzureSpeechProvider(TranscriptionProvider):
         params = self._build_params(language)
         headers = {
             "Ocp-Apim-Subscription-Key": self.api_key,
-            "Content-Type": self._content_type(audio_file),
+            "Content-Type": "audio/wav; codecs=audio/pcm; samplerate=16000",
             "Accept": "application/json",
         }
 
@@ -92,6 +91,7 @@ class AzureSpeechProvider(TranscriptionProvider):
                 headers=headers,
                 params=params,
                 data=f.read(),
+                timeout=60,
             )
 
         if response.status_code != 200:
@@ -199,13 +199,6 @@ class AzureSpeechProvider(TranscriptionProvider):
         if not language:
             return "en-US"
         return LANGUAGE_ALIASES.get(language.lower(), language)
-
-    @staticmethod
-    def _content_type(audio_file: str) -> str:
-        extension = Path(audio_file).suffix.lower()
-        if extension == ".ogg":
-            return "audio/ogg; codecs=opus"
-        return "audio/wav; codecs=audio/pcm; samplerate=16000"
 
     @staticmethod
     def _error_text(response) -> str:

--- a/tests/providers/test_group_e.py
+++ b/tests/providers/test_group_e.py
@@ -124,6 +124,7 @@ class TestAzureSpeechProvider:
             "audio/wav; codecs=audio/pcm; samplerate=16000"
         )
         assert call_kwargs["data"] == b"fake wav audio"
+        assert call_kwargs["timeout"] == 60
 
     @patch.dict(
         os.environ,

--- a/tests/providers/test_group_e.py
+++ b/tests/providers/test_group_e.py
@@ -1,0 +1,251 @@
+# ABOUTME: Tests for additional REST transcription providers
+# ABOUTME: Covers Azure AI Speech short-audio REST integration
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from sapat.providers.base import TranscriptionResult
+
+
+class FakeResponse:
+    """Minimal requests.Response stand-in for mocked HTTP calls."""
+
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def wav_audio(tmp_path):
+    path = tmp_path / "sample.wav"
+    path.write_bytes(b"fake wav audio")
+    return str(path)
+
+
+class TestAzureSpeechProvider:
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_ENDPOINT": (
+                "https://speech.example.cognitiveservices.azure.com"
+            ),
+        },
+        clear=True,
+    )
+    def test_is_available_with_key_and_endpoint(self):
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        assert AzureSpeechProvider.is_available() is True
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_REGION": "westeurope",
+        },
+        clear=True,
+    )
+    def test_is_available_with_key_and_region_fallback(self):
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        assert AzureSpeechProvider.is_available() is True
+
+    @patch.dict(os.environ, {"AZURE_SPEECH_KEY": "test-key"}, clear=True)
+    def test_is_not_available_without_endpoint_or_region(self):
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        assert AzureSpeechProvider.is_available() is False
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_REGION": "westeurope",
+        },
+        clear=True,
+    )
+    def test_resolve_model_aliases(self):
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        provider = AzureSpeechProvider()
+        assert provider.resolve_model("default") == "conversation"
+        assert provider.resolve_model("conversation") == "conversation"
+        assert provider.resolve_model("dictation") == "dictation"
+        assert provider.resolve_model("interactive") == "interactive"
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_ENDPOINT": (
+                "https://speech.example.cognitiveservices.azure.com"
+            ),
+        },
+        clear=True,
+    )
+    @patch("sapat.providers.azure_speech.requests.post")
+    def test_transcribe_sends_wav_to_resource_endpoint(self, mock_post, wav_audio):
+        mock_post.return_value = FakeResponse(
+            200,
+            {
+                "RecognitionStatus": "Success",
+                "DisplayText": "Hello from Azure Speech.",
+                "Duration": "50000000",
+            },
+        )
+
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        provider = AzureSpeechProvider()
+        result = provider.transcribe(wav_audio, model="conversation", language="en")
+
+        assert isinstance(result, TranscriptionResult)
+        assert result.text == "Hello from Azure Speech."
+        assert result.language == "en-US"
+        assert result.duration == 5.0
+
+        mock_post.assert_called_once()
+        url = mock_post.call_args.args[0]
+        call_kwargs = mock_post.call_args.kwargs
+        assert url == (
+            "https://speech.example.cognitiveservices.azure.com/"
+            "stt/speech/recognition/conversation/cognitiveservices/v1"
+        )
+        assert call_kwargs["params"] == {"language": "en-US", "format": "simple"}
+        assert call_kwargs["headers"]["Ocp-Apim-Subscription-Key"] == "test-key"
+        assert call_kwargs["headers"]["Content-Type"] == (
+            "audio/wav; codecs=audio/pcm; samplerate=16000"
+        )
+        assert call_kwargs["data"] == b"fake wav audio"
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_REGION": "westeurope",
+            "AZURE_SPEECH_RESPONSE_FORMAT": "detailed",
+            "AZURE_SPEECH_PROFANITY": "raw",
+        },
+        clear=True,
+    )
+    @patch("sapat.providers.azure_speech.requests.post")
+    def test_transcribe_uses_detailed_response_fields(self, mock_post, wav_audio):
+        mock_post.return_value = FakeResponse(
+            200,
+            {
+                "RecognitionStatus": "Success",
+                "NBest": [{"Display": "Detailed transcript."}],
+            },
+        )
+
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        provider = AzureSpeechProvider()
+        result = provider.transcribe(wav_audio, model="default", language="bg")
+
+        assert result.text == "Detailed transcript."
+        assert mock_post.call_args.kwargs["params"] == {
+            "language": "bg-BG",
+            "format": "detailed",
+            "profanity": "raw",
+        }
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_REGION": "westeurope",
+            "AZURE_SPEECH_ENDPOINT": "https://speech.example.cognitiveservices.azure.com",
+        },
+        clear=True,
+    )
+    def test_builds_resource_endpoint_with_stt_prefix(self):
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        provider = AzureSpeechProvider()
+        assert provider._build_endpoint("conversation") == (
+            "https://speech.example.cognitiveservices.azure.com/"
+            "stt/speech/recognition/conversation/cognitiveservices/v1"
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_REGION": "westeurope",
+        },
+        clear=True,
+    )
+    def test_builds_regional_fallback_endpoint(self):
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        provider = AzureSpeechProvider()
+        assert provider._build_endpoint("conversation") == (
+            "https://westeurope.stt.speech.microsoft.com/"
+            "speech/recognition/conversation/cognitiveservices/v1"
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_REGION": "westeurope",
+        },
+        clear=True,
+    )
+    @patch("sapat.providers.azure_speech.requests.post")
+    def test_http_error_raises_message_from_payload(self, mock_post, wav_audio):
+        mock_post.return_value = FakeResponse(
+            401,
+            {"error": {"message": "invalid key"}},
+            text="Unauthorized",
+        )
+
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        provider = AzureSpeechProvider()
+        with pytest.raises(RuntimeError, match="invalid key"):
+            provider.transcribe(wav_audio, model="conversation", language="en-US")
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_REGION": "westeurope",
+        },
+        clear=True,
+    )
+    @patch("sapat.providers.azure_speech.requests.post")
+    def test_no_match_returns_empty_transcript(self, mock_post, wav_audio):
+        mock_post.return_value = FakeResponse(200, {"RecognitionStatus": "NoMatch"})
+
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        provider = AzureSpeechProvider()
+        result = provider.transcribe(wav_audio, model="conversation", language="en-US")
+
+        assert result.text == ""
+        assert result.raw_response == {"RecognitionStatus": "NoMatch"}
+
+    @patch.dict(
+        os.environ,
+        {
+            "AZURE_SPEECH_KEY": "test-key",
+            "AZURE_SPEECH_REGION": "westeurope",
+            "AZURE_SPEECH_RESPONSE_FORMAT": "xml",
+        },
+        clear=True,
+    )
+    def test_invalid_response_format_raises(self):
+        from sapat.providers.azure_speech import AzureSpeechProvider
+
+        provider = AzureSpeechProvider()
+        with pytest.raises(ValueError, match="AZURE_SPEECH_RESPONSE_FORMAT"):
+            provider._build_params("en")


### PR DESCRIPTION
Sapat already supports Azure OpenAI, but that route expects a Whisper deployment. This adds a separate `azure_speech` provider for people who have a regular Azure AI Speech resource and want to use the short-audio REST API directly.

The provider accepts the resource key and endpoint, keeps the regional URL as a fallback, and handles language aliases, simple or detailed results, profanity settings, and `NoMatch` responses. I also added the setup variables to `.env.example`, documented the command in the README, and covered the request and response behavior with mocked tests.

I ran the focused provider, registry, CLI, and base tests locally: 36 passed. The complete suite reached 186 passing tests; its only failure is the existing WhisperX temporary-path test on Windows, in code untouched by this change.

Related to daytonaio/content#13.
